### PR TITLE
Refactoring WidgetEntry for improved modularity

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-use std::process::Command;
 use std::env;
+use std::process::Command;
 
 fn main() {
     // Tell Cargo to rerun the build script if the build script or scripts/install_bootstrapcss.sh files change.
@@ -9,7 +9,10 @@ fn main() {
     let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     Command::new("sh")
         .arg("-C")
-        .arg(format!("{}/scripts/install_bootstrapcss.sh", cargo_manifest_dir))
+        .arg(format!(
+            "{}/scripts/install_bootstrapcss.sh",
+            cargo_manifest_dir
+        ))
         .output()
         .expect("sh command failed to start");
 }

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -2,8 +2,15 @@ use base64::{engine::general_purpose, Engine as _};
 use dioxus::{prelude::*};
 use std::fmt;
 
-pub const TITLE: &str = "Base64 Encoder / Decoder";
-pub const DESCRIPTION: &str = "Encode and decode base64 strings";
+use crate::widget_entry;
+
+pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+    title: "Base64 Encoder / Decoder",
+    description: "Encode and decode base64 strings",
+    widget_type: widget_entry::WidgetType::Encoder,
+    widget: widget_entry::Widget::Base64Encoder,
+    function: base64_encoder,
+};
 
 pub fn base64_encoder(cx: Scope) -> Element {
     use_shared_state_provider(cx, || EncoderValue {
@@ -15,7 +22,7 @@ pub fn base64_encoder(cx: Scope) -> Element {
             class: "base64-encoder",
             div {
                 class: "widget-title",
-                TITLE
+                WIDGET_ENTRY.title
             }
             div {
                 class: "widget-body",

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -1,5 +1,5 @@
 use base64::{engine::general_purpose, Engine as _};
-use dioxus::{prelude::*};
+use dioxus::prelude::*;
 use std::fmt;
 
 use crate::widget_entry;

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -7,7 +7,6 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Base64 Encoder / Decoder",
     description: "Encode and decode base64 strings",
-    widget_type: widget_entry::WidgetType::Encoder,
     widget: widget_entry::Widget::Base64Encoder,
     function: base64_encoder,
 };

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -5,7 +5,6 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Color Picker",
     description: "Pick a color and get its output in different formats",
-    widget_type: widget_entry::WidgetType::Media,
     widget: widget_entry::Widget::ColorPicker,
     function: color_picker,
 };

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -3,14 +3,14 @@ use dioxus::prelude::*;
 use crate::widget_entry;
 
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
-    title: "JSON <> YAML Converter",
-    description: "Convert between JSON and YAML file formats",
-    widget_type: widget_entry::WidgetType::Converter,
-    widget: widget_entry::Widget::JsonYamlConverter,
-    function: json_yaml_converter,
+    title: "Color Picker",
+    description: "Pick a color and get its output in different formats",
+    widget_type: widget_entry::WidgetType::Media,
+    widget: widget_entry::Widget::ColorPicker,
+    function: color_picker,
 };
 
-pub fn json_yaml_converter(cx: Scope) -> Element {
+pub fn color_picker(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             div {

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -1,14 +1,21 @@
 use dioxus::prelude::*;
 
-pub const TITLE: &str = "Date Converter";
-pub const DESCRIPTION: &str = "Convert dates between formats";
+use crate::widget_entry;
+
+pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+    title: "Date Converter",
+    description: "Convert dates between formats",
+    widget_type: widget_entry::WidgetType::Converter,
+    widget: widget_entry::Widget::DateConverter,
+    function: date_converter,
+};
 
 pub fn date_converter(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             div {
                 class: "widget-title",
-                TITLE
+                WIDGET_ENTRY.title
             }
         }
     })

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -5,7 +5,6 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Date Converter",
     description: "Convert dates between formats",
-    widget_type: widget_entry::WidgetType::Converter,
     widget: widget_entry::Widget::DateConverter,
     function: date_converter,
 };

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -5,7 +5,6 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "JSON <> YAML Converter",
     description: "Convert between JSON and YAML file formats",
-    widget_type: widget_entry::WidgetType::Converter,
     widget: widget_entry::Widget::JsonYamlConverter,
     function: json_yaml_converter,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,12 @@ use dioxus_desktop::{Config, WindowBuilder};
 
 use phf::phf_map;
 
-pub mod widget_entry;
 pub mod base64_encoder;
+pub mod color_picker;
 pub mod date_converter;
 pub mod json_yaml_converter;
 pub mod number_base_converter;
-pub mod color_picker;
+pub mod widget_entry;
 
 fn main() {
     // launch the dioxus app in a webview
@@ -99,7 +99,10 @@ fn app(cx: Scope) -> Element {
 fn widget_view(cx: Scope) -> Element {
     let state = use_shared_state::<WidgetViewState>(cx).unwrap();
 
-    fn set_display(current_widget: widget_entry::Widget, desired_widget: widget_entry::Widget) -> &'static str {
+    fn set_display(
+        current_widget: widget_entry::Widget,
+        desired_widget: widget_entry::Widget,
+    ) -> &'static str {
         if current_widget == desired_widget {
             "block"
         } else {
@@ -160,8 +163,6 @@ fn home_page(cx: Scope) -> Element {
         }
     })
 }
-
-
 
 struct WidgetViewState {
     current_widget: widget_entry::Widget,

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -1,8 +1,15 @@
 use dioxus::prelude::*;
 use std::fmt;
 
-pub const TITLE: &str = "Number Base Converter";
-pub const DESCRIPTION: &str = "Convert numbers between binary, octal, decimal, and hexadecimal";
+use crate::widget_entry;
+
+pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+    title: "Number Base Converter",
+    description: "Convert numbers between binary, octal, decimal, and hexadecimal",
+    widget_type: widget_entry::WidgetType::Converter,
+    widget: widget_entry::Widget::NumberBaseConverter,
+    function: number_base_converter,
+};
 
 pub fn number_base_converter(cx: Scope) -> Element {
     use_shared_state_provider(cx, || ConverterValue(0));
@@ -10,7 +17,7 @@ pub fn number_base_converter(cx: Scope) -> Element {
         div {
             div {
                 class: "widget-title",
-                TITLE
+                WIDGET_ENTRY.title
             }
             div {
                 class: "widget-body",

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -6,7 +6,6 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Number Base Converter",
     description: "Convert numbers between binary, octal, decimal, and hexadecimal",
-    widget_type: widget_entry::WidgetType::Converter,
     widget: widget_entry::Widget::NumberBaseConverter,
     function: number_base_converter,
 };

--- a/src/widget_entry.rs
+++ b/src/widget_entry.rs
@@ -4,16 +4,8 @@ use dioxus::prelude::*;
 pub struct WidgetEntry {
     pub title: &'static str,
     pub description: &'static str,
-    pub widget_type: WidgetType,
     pub widget: Widget,
     pub function: fn(cx: Scope) -> Element,
-}
-
-#[derive(PartialEq, Eq, Hash)]
-pub enum WidgetType {
-    Converter,
-    Encoder,
-    Media,
 }
 
 #[derive(PartialEq, Eq, Copy, Clone)]

--- a/src/widget_entry.rs
+++ b/src/widget_entry.rs
@@ -1,0 +1,27 @@
+use dioxus::prelude::*;
+
+#[derive(PartialEq, Eq)]
+pub struct WidgetEntry {
+    pub title: &'static str,
+    pub description: &'static str,
+    pub widget_type: WidgetType,
+    pub widget: Widget,
+    pub function: fn(cx: Scope) -> Element,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum WidgetType {
+    Converter,
+    Encoder,
+    Media,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub enum Widget {
+    Base64Encoder,
+    DateConverter,
+    NumberBaseConverter,
+    JsonYamlConverter,
+    ColorPicker,
+    Home,
+}

--- a/style/style.css
+++ b/style/style.css
@@ -58,7 +58,7 @@ body {
 }
 
 .home-page .card .card-body {
-  font-size: .8em;
+  font-size: 0.8em;
 }
 
 .widget-title {


### PR DESCRIPTION
Moving WidgetEntry and corresponding enums to its own module. Moving individual WidgetEntry declarations for each widget to the corresponding module file for a more declarative format. I've also removed the unused WidgetType enum. I want to figure out if I can simplify the Widget enum so that I can either make it declarative within each widget module or remove it entirely. I also figured out how to allow the main widget-view to render the individual widgets without needing to declare each explicitly, instead I can just iterate through the WIDGETS hashmap! Yay modularity!