### PR TITLE
Use Dioxus Router for displaying views for each widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Dev Widgets"
 base64 = "0.21.2"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
+dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 phf = { version = "0.11.1", features = ["macros"] }
 
 [package.metadata.bundle]

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -7,7 +7,7 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Base64 Encoder / Decoder",
     description: "Encode and decode base64 strings",
-    widget: widget_entry::Widget::Base64Encoder,
+    path: "/base64-encoder",
     function: base64_encoder,
 };
 

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -5,7 +5,7 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Color Picker",
     description: "Pick a color and get its output in different formats",
-    widget: widget_entry::Widget::ColorPicker,
+    path: "/color-picker",
     function: color_picker,
 };
 

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -5,7 +5,7 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Date Converter",
     description: "Convert dates between formats",
-    widget: widget_entry::Widget::DateConverter,
+    path: "/date-converter",
     function: date_converter,
 };
 

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -5,7 +5,7 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "JSON <> YAML Converter",
     description: "Convert between JSON and YAML file formats",
-    widget: widget_entry::Widget::JsonYamlConverter,
+    path: "/json-yaml-converter",
     function: json_yaml_converter,
 };
 

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -6,7 +6,7 @@ use crate::widget_entry;
 pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     title: "Number Base Converter",
     description: "Convert numbers between binary, octal, decimal, and hexadecimal",
-    widget: widget_entry::Widget::NumberBaseConverter,
+    path: "/number-base-converter",
     function: number_base_converter,
 };
 

--- a/src/widget_entry.rs
+++ b/src/widget_entry.rs
@@ -4,16 +4,6 @@ use dioxus::prelude::*;
 pub struct WidgetEntry {
     pub title: &'static str,
     pub description: &'static str,
-    pub widget: Widget,
+    pub path: &'static str,
     pub function: fn(cx: Scope) -> Element,
-}
-
-#[derive(PartialEq, Eq, Copy, Clone)]
-pub enum Widget {
-    Base64Encoder,
-    DateConverter,
-    NumberBaseConverter,
-    JsonYamlConverter,
-    ColorPicker,
-    Home,
 }


### PR DESCRIPTION
Before, I was using a complicated setup of a shared WidgetViewState that limited my ability to make the widget views more declarative. Now, I am using the Dioxus Router component to display different widget views and switch between them in a much more streamlined fashion. I was able to remove the WidgetViewState struct and the Widget enum entirely. Now, adding a new widget is as simple as creating the widget module with a WIDGET_ENTRY struct and then adding it to the WIDGETS hashmap in main.rs.