### PR TITLE
Fixing a bug in widget state by using Children prop

### DIFF
--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -11,7 +11,7 @@ pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     function: base64_encoder,
 };
 
-pub fn base64_encoder<'a>(cx: &'a ScopeState) -> Element<'a> {
+pub fn base64_encoder(cx: Scope) -> Element {
     use_shared_state_provider(cx, || EncoderValue {
         encoded_value: String::new(),
         decoded_value: String::new(),

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -9,7 +9,7 @@ pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     function: color_picker,
 };
 
-pub fn color_picker<'a>(cx: &'a ScopeState) -> Element<'a> {
+pub fn color_picker(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "color-picker"

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -9,7 +9,7 @@ pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     function: date_converter,
 };
 
-pub fn date_converter<'a>(cx: &'a ScopeState) -> Element<'a> {
+pub fn date_converter(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "date-converter"

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -9,7 +9,7 @@ pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     function: json_yaml_converter,
 };
 
-pub fn json_yaml_converter<'a>(cx: &'a ScopeState) -> Element<'a> {
+pub fn json_yaml_converter(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "json-yaml-converter"

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,8 @@ fn app(cx: Scope) -> Element {
                     Route {
                         to: HOME_PAGE_WIDGET_ENTRY.path,
                         widget_view {
-                            widget_entry: HOME_PAGE_WIDGET_ENTRY
+                            title: HOME_PAGE_WIDGET_ENTRY.title,
+                            children: (HOME_PAGE_WIDGET_ENTRY.function)(cx)
                         }
                     }
                     for widget_type in WIDGETS.keys() {
@@ -132,7 +133,8 @@ fn app(cx: Scope) -> Element {
                             Route {
                                 to: widget_entry.path,
                                 widget_view {
-                                    widget_entry: *widget_entry
+                                    title: widget_entry.title,
+                                    children: (widget_entry.function)(cx)
                                 }
                             }
                         }
@@ -144,18 +146,23 @@ fn app(cx: Scope) -> Element {
     })
 }
 
-#[inline_props]
-fn widget_view(cx: Scope, widget_entry: widget_entry::WidgetEntry) -> Element {
+fn widget_view<'a>(cx: Scope<'a, WidgetViewProps<'a>>) -> Element {
     cx.render(rsx! {
         h3 {
             class: "widget-title",
-            widget_entry.title
+            cx.props.title
         }
         div {
             class: "widget-body",
-            (widget_entry.function)(cx.scope)
+            &cx.props.children
         }
     })
+}
+
+#[derive(Props)]
+struct WidgetViewProps<'a> {
+    title: &'a str,
+    children: Element<'a>,
 }
 
 #[inline_props]
@@ -187,7 +194,7 @@ static HOME_PAGE_WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetE
     function: home_page,
 };
 
-fn home_page<'a>(cx: &'a ScopeState) -> Element<'a> {
+fn home_page(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "home-page d-flex flex-row flex-wrap gap-2",

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -10,7 +10,7 @@ pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
     function: number_base_converter,
 };
 
-pub fn number_base_converter<'a>(cx: &'a ScopeState) -> Element<'a> {
+pub fn number_base_converter(cx: Scope) -> Element {
     use_shared_state_provider(&cx, || ConverterValue(0));
     use_shared_state_provider(&cx, || FormatNumberState(false));
 

--- a/src/widget_entry.rs
+++ b/src/widget_entry.rs
@@ -1,9 +1,9 @@
 use dioxus::prelude::*;
 
-#[derive(PartialEq, Eq, Props, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct WidgetEntry {
     pub title: &'static str,
     pub description: &'static str,
     pub path: &'static str,
-    pub function: for<'a> fn(cx: &'a ScopeState) -> Element<'a>,
+    pub function: fn(cx: Scope) -> Element,
 }

--- a/style/style.css
+++ b/style/style.css
@@ -54,6 +54,7 @@ body {
   width: 100%;
   overflow-y: scroll;
   padding-left: 1em;
+  padding-right: 1em;
   clip-path: inset(0 0 0 0);
 }
 


### PR DESCRIPTION
This regression was introduced when I moved the widget_view into its own function. This broke the ability for widgets to store state when they went out of view. I've reworked this setup using the Children prop as recommended in the Dioxus docs