### PR TITLE
Migrate stylesheets to Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,12 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-# Bootstrap minified CSS
-style/bootstrap.min.css
+# Bootstrap
+bootstrap/
+style/
 
 # macOS files
 .DS_Store
+
+# Dioxus
+dioxusin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ base64 = "0.21.2"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
+grass = "0.12.4"
 phf = { version = "0.11.1", features = ["macros"] }
 
 [package.metadata.bundle]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,21 @@ name = "dev-widgets"
 version = "0.1.0"
 edition = "2021"
 description = "Dev Widgets"
+readme = "README.md"
+
+[build-dependencies]
+curl = "0.4.44"
+grass = "0.12.4"
+zip-extract = "0.1.2"
+
+[dev-dependencies]
+dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 
 [dependencies]
 base64 = "0.21.2"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
 dioxus-router = { git = "https://github.com/DioxusLabs/dioxus", rev = "b264211cc2685232426317d3055046838047d3db" }
-grass = "0.12.4"
 phf = { version = "0.11.1", features = ["macros"] }
 
 [package.metadata.bundle]

--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,10 @@ fn main() {
         .iter()
         .collect();
 
+        // Create grass output path if it does not already exist
+        let grass_output_dir = grass_output_path.parent().unwrap();
+        std::fs::create_dir_all(grass_output_dir).unwrap();
+
         let mut grass_output_file = File::create(&grass_output_path).unwrap();
 
         // We want to compress the output CSS in release builds, but not in debug builds.

--- a/scripts/install_bootstrapcss.sh
+++ b/scripts/install_bootstrapcss.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Install Bootstrap CSS
-echo "Installing Bootstrap CSS..."
-cd $CARGO_MANIFEST_DIR/style
-curl -o "bootstrap.min.css" https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css
-cd -
-echo "Bootstrap CSS installed"

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1,3 +1,5 @@
+@import "../bootstrap/scss/bootstrap";
+
 html {
   overscroll-behavior: none;
 }


### PR DESCRIPTION
This converts the main style.css to a Sass stylesheet. It also moves the Bootstrap install code to a pure Rust script. The Sass stylesheets are compiled into CSS using the grass crate.