### PR TITLE
Redo sidebar as accordion with icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Cargo.lock
 # Bootstrap
 bootstrap/
 style/
+js/
 
 # macOS files
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ dioxus-desktop = "0.3.0"
 dioxus-router = "0.3.0"
 dioxus-interpreter-js = "0.3.3"
 phf = { version = "0.11.1", features = ["macros"] }
+web-sys = "0.3.64"
+dioxus-material-icons = "1.1.0"
+dioxus-free-icons = "0.6.0"
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,7 @@ dioxus-desktop = "0.3.0"
 dioxus-router = "0.3.0"
 dioxus-interpreter-js = "0.3.3"
 phf = { version = "0.11.1", features = ["macros"] }
-web-sys = "0.3.64"
-dioxus-material-icons = "1.1.0"
-dioxus-free-icons = "0.6.0"
+dioxus-free-icons = { version = "0.6.0", features = ["bootstrap"] }
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ phf = { version = "0.11.1", features = ["macros"] }
 name = "Dev Widgets"
 identifier = "com.esimkowitz.devwidgets"
 version = "0.1.0"
-resources = ["style/*css"]
+resources = ["style/*css", "js/*js"]
 copyright = "Copyright (c) Evan Simkowitz 2023. All rights reserved."
 category = "Developer Tool"
 short_description = "A set of helpful widgets written in Rust."

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -64,6 +64,11 @@ body {
   width: 100%;
 }
 
+.home-icon {
+  height: 1em;
+  width: 1em;
+}
+
 .home-page .card {
   width: 10em;
   height: 10em;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -14,6 +14,7 @@ body {
 }
 
 .container-fluid {
+  @extend .d-flex, .flex-row, .wrapper, .pe-0;
   width: 100vw;
   height: 100vh;
   overflow-y: scroll;
@@ -37,21 +38,26 @@ body {
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12), 0 4px 8px rgba(0, 0, 0, 0.06);
 }
 
+.sidebar {
+  @extend .flex-row, .d-flex;
+}
+
 .sidebar-list {
-  flex-basis: 14em;
   overflow-y: scroll;
-  min-width: 12em;
-  padding-right: 1em;
-}
-
-.sidebar-list .btn {
   width: 100%;
-  text-align: left;
-  white-space: nowrap;
-}
 
-.sidebar-list .accordion-button:not(.collapsed){
-  background-color: var(--bs-body-bg);
+  .btn {
+    @extend .btn-sm;
+    width: 100%;
+    text-align: left;
+    white-space: nowrap;
+  }
+  .accordion {
+    @extend .accordion-flush, .flex-column, .ms-2, .mb-2, .pt-2, .pe-3;
+  }
+  .accordion-button:not(.collapsed) {
+    background-color: var(--bs-body-bg);
+  }
 }
 
 .widget-view {
@@ -59,6 +65,7 @@ body {
   overflow-y: scroll;
   padding-left: 1em;
   padding-right: 1em;
+  clip-path: inset(0 0 0 0);
 }
 
 .card-body {
@@ -69,22 +76,28 @@ body {
   height: 1em;
   width: 1em;
   margin-right: 0.5em;
+  margin-top: -0.25em;
 }
 
-.home-page .card {
-  width: 10em;
-  height: 10em;
+.home-page {
+  @extend .d-flex, .flex-row, .flex-wrap, .gap-2;
+
+  .card {
+    @extend .p-0;
+    width: 10em;
+    height: 10em;
+
+    .card-title {
+      font-size: 1.2em;
+      font-weight: bold;
+    }
+    .card-body {
+      font-size: 0.8em;
+    }
+  }
 }
 
-.home-page .card .card-title {
-  font-size: 1.2em;
-  font-weight: bold;
-}
-
-.home-page .card .card-body {
-  font-size: 0.8em;
-}
-
+$widget-title-left-overflow: 0.5em;
 .widget-title {
   position: fixed;
   top: 0;
@@ -92,10 +105,10 @@ body {
   width: 100%;
   z-index: 100;
   /* prevent widget body elements that may overflow the margin from appearing behind the title bar */
-  margin-left: -2em;
+  margin-left: -$widget-title-left-overflow;
   padding-top: 0.25em;
   padding-bottom: 0.25em;
-  padding-left: 2em;
+  padding-left: $widget-title-left-overflow;
 }
 
 .widget-body {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -40,6 +40,7 @@ body {
 
 .sidebar {
   @extend .flex-row, .d-flex;
+  width: 14em;
 }
 
 .sidebar-list {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -48,8 +48,8 @@ body {
   text-align: left;
 }
 
-.sidebar-list .nav-item {
-  width: 100%;
+.sidebar-list .accordion-button:not(.collapsed){
+  background-color: var(--bs-body-bg);
 }
 
 .widget-view {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -64,9 +64,10 @@ body {
   width: 100%;
 }
 
-.home-icon {
+.sidebar-icon {
   height: 1em;
   width: 1em;
+  margin-right: 0.5em;
 }
 
 .home-page .card {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -17,6 +17,7 @@ body {
   width: 100vw;
   height: 100vh;
   overflow-y: scroll;
+  justify-content: flex-start;
 }
 
 /* Taken from https://ordinarycoders.com/blog/article/codepen-bootstrap-card-hovers */
@@ -37,15 +38,16 @@ body {
 }
 
 .sidebar-list {
-  width: 14em;
-  min-width: 14em;
+  flex-basis: 14em;
   overflow-y: scroll;
-  z-index: 101;
+  min-width: 12em;
+  padding-right: 1em;
 }
 
 .sidebar-list .btn {
   width: 100%;
   text-align: left;
+  white-space: nowrap;
 }
 
 .sidebar-list .accordion-button:not(.collapsed){
@@ -57,7 +59,6 @@ body {
   overflow-y: scroll;
   padding-left: 1em;
   padding-right: 1em;
-  clip-path: inset(0 0 0 0);
 }
 
 .card-body {

--- a/src/accordion.rs
+++ b/src/accordion.rs
@@ -1,7 +1,8 @@
+#![allow(non_snake_case)]
 use dioxus::prelude::*;
 
 #[inline_props]
-pub fn accordion<'a>(
+pub fn Accordion<'a>(
     cx: Scope<'a>,
     children: Element<'a>,
     title: &'a str,

--- a/src/accordion.rs
+++ b/src/accordion.rs
@@ -1,0 +1,46 @@
+use dioxus::prelude::*;
+
+#[inline_props]
+pub fn accordion<'a>(
+    cx: Scope<'a>,
+    children: Element<'a>,
+    title: &'a str,
+    is_open: Option<bool>,
+) -> Element {
+    let default_open_flag = !is_open.unwrap_or(false);
+    let is_close_accordion = use_state(&cx, || default_open_flag);
+    let buttoncss = if *is_close_accordion.get() {
+        "accordion-button p-2 collapsed"
+    } else {
+        "accordion-button p-2"
+    };
+    let accordioncss = if *is_close_accordion.get() {
+        "accordion-collapse collapse"
+    } else {
+        "accordion-collapse collapse show"
+    };
+    cx.render(rsx! {
+        div {
+            class: "accordion-item",
+            h3 {
+                class: "accordion-header",
+                button {
+                    class: "{buttoncss}",
+                    r#type: "button",
+                    aria_expanded: "{!is_close_accordion.get()}",
+                    onclick: move |_| {
+                        is_close_accordion.set(!*is_close_accordion.get());
+                    },
+                    *title
+                }
+            }
+            div {
+                class: "{accordioncss}",
+                div {
+                    class: "accordion-body p-0",
+                    children
+                }
+            }
+        }
+    })
+}

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -3,7 +3,7 @@ use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
 use std::fmt;
 
-use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
+use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Base64 Encoder / Decoder",
@@ -11,7 +11,11 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Encode and decode base64 strings",
     path: "/base64-encoder",
     function: base64_encoder,
-    icon: sidebar_icon::<BsHash>,
+    icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
+};
+
+const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
+    icon: BsHash,
 };
 
 pub fn base64_encoder(cx: Scope) -> Element {

--- a/src/base64_encoder.rs
+++ b/src/base64_encoder.rs
@@ -1,15 +1,17 @@
 use base64::{engine::general_purpose, Engine as _};
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsHash;
 use std::fmt;
 
-use crate::widget_entry;
+use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
 
-pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Base64 Encoder / Decoder",
     short_title: "Base64",
     description: "Encode and decode base64 strings",
     path: "/base64-encoder",
     function: base64_encoder,
+    icon: sidebar_icon::<BsHash>,
 };
 
 pub fn base64_encoder(cx: Scope) -> Element {

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,7 +1,8 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::bs_icons::BsHash;
+use dioxus_free_icons::icons::bs_icons::{BsHash, BsEyedropper};
+use once_cell::sync::Lazy;
 
-use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
+use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Color Picker",
@@ -9,7 +10,11 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Pick a color and get its output in different formats",
     path: "/color-picker",
     function: color_picker,
-    icon: sidebar_icon::<BsHash>,
+    icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
+};
+
+const SIDEBAR_ICON: SidebarIcon<BsEyedropper> = SidebarIcon {
+    icon: BsEyedropper,
 };
 
 pub fn color_picker(cx: Scope) -> Element {

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,13 +1,15 @@
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsHash;
 
-use crate::widget_entry;
+use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
 
-pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Color Picker",
     short_title: "Color Picker",
     description: "Pick a color and get its output in different formats",
     path: "/color-picker",
     function: color_picker,
+    icon: sidebar_icon::<BsHash>,
 };
 
 pub fn color_picker(cx: Scope) -> Element {

--- a/src/color_picker.rs
+++ b/src/color_picker.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::bs_icons::{BsHash, BsEyedropper};
-use once_cell::sync::Lazy;
+use dioxus_free_icons::icons::bs_icons::BsEyedropper;
 
 use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -1,7 +1,8 @@
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
+use once_cell::sync::Lazy;
 
-use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
+use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Date Converter",
@@ -9,10 +10,15 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Convert dates between formats",
     path: "/date-converter",
     function: date_converter,
-    icon: sidebar_icon::<BsHash>,
+    icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
+};
+
+const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
+    icon: BsHash,
 };
 
 pub fn date_converter(cx: Scope) -> Element {
+    let x = Box::new(BsHash);
     cx.render(rsx! {
         div {
             class: "date-converter"

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -1,13 +1,15 @@
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsHash;
 
-use crate::widget_entry;
+use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
 
-pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Date Converter",
     short_title: "Date",
     description: "Convert dates between formats",
     path: "/date-converter",
     function: date_converter,
+    icon: sidebar_icon::<BsHash>,
 };
 
 pub fn date_converter(cx: Scope) -> Element {

--- a/src/date_converter.rs
+++ b/src/date_converter.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::bs_icons::BsHash;
-use once_cell::sync::Lazy;
+use dioxus_free_icons::icons::bs_icons::BsClock;
 
 use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
@@ -13,12 +12,11 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
 };
 
-const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
-    icon: BsHash,
+const SIDEBAR_ICON: SidebarIcon<BsClock> = SidebarIcon {
+    icon: BsClock,
 };
 
 pub fn date_converter(cx: Scope) -> Element {
-    let x = Box::new(BsHash);
     cx.render(rsx! {
         div {
             class: "date-converter"

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::bs_icons::BsHash;
+use dioxus_free_icons::icons::bs_icons::BsFileText;
 
 use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
@@ -12,8 +12,8 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
 };
 
-const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
-    icon: BsHash,
+const SIDEBAR_ICON: SidebarIcon<BsFileText> = SidebarIcon {
+    icon: BsFileText,
 };
 
 pub fn json_yaml_converter(cx: Scope) -> Element {

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
-use once_cell::sync::Lazy;
 
 use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -1,7 +1,8 @@
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
+use once_cell::sync::Lazy;
 
-use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
+use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "JSON <> YAML Converter",
@@ -9,7 +10,11 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Convert between JSON and YAML file formats",
     path: "/json-yaml-converter",
     function: json_yaml_converter,
-    icon: sidebar_icon::<BsHash>,
+    icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
+};
+
+const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
+    icon: BsHash,
 };
 
 pub fn json_yaml_converter(cx: Scope) -> Element {

--- a/src/json_yaml_converter.rs
+++ b/src/json_yaml_converter.rs
@@ -1,13 +1,15 @@
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsHash;
 
-use crate::widget_entry;
+use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
 
-pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "JSON <> YAML Converter",
     short_title: "JSON <> YAML",
     description: "Convert between JSON and YAML file formats",
     path: "/json-yaml-converter",
     function: json_yaml_converter,
+    icon: sidebar_icon::<BsHash>,
 };
 
 pub fn json_yaml_converter(cx: Scope) -> Element {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,12 +92,12 @@ fn main() {
 fn app(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
-            class: "container-fluid d-flex flex-row wrapper pe-0",
+            class: "container-fluid",
             Router {
                 div {
                     class: "sidebar-list",
                     div {
-                        class: "accordion accordion-flush flex-column ms-2 mb-2 pt-2 pe-3",
+                        class: "accordion",
                         sidebar_list_item {
                             widget_entry: HOME_PAGE_WIDGET_ENTRY,
                             icon: (HOME_PAGE_WIDGET_ENTRY.icon)(cx)
@@ -173,7 +173,7 @@ fn sidebar_list_item<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element
 
     cx.render(rsx! {
         Link {
-            class: "btn btn-sm {active_str}",
+            class: "btn",
             to: widget_entry.path
             icon
             widget_entry.short_title
@@ -193,11 +193,11 @@ static HOME_PAGE_WIDGET_ENTRY: WidgetEntry = WidgetEntry {
 fn home_page(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
-            class: "home-page d-flex flex-row flex-wrap gap-2",
+            class: "home-page",
             for widget_type in WIDGETS.keys() {
                 for widget_entry in WIDGETS.get(widget_type).unwrap() {
                     div {
-                        class: "card p-0",
+                        class: "card",
                         div {
                             class: "card-body",
                             div {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
+#![allow(non_snake_case)]
 // import the prelude to get access to the `rsx!` macro and the `Scope` and `Element` types
 use dioxus::prelude::*;
 use dioxus_desktop::{Config as DesktopConfig, WindowBuilder};
-use dioxus_free_icons::{icons::bs_icons::BsHouseDoorFill, Icon};
+use dioxus_free_icons::icons::bs_icons::BsHouseDoorFill;
 use dioxus_router::{use_route, Link, Redirect, Route, Router};
 
 #[cfg(debug_assertions)]
 use dioxus_hot_reload::{hot_reload_init, Config as HotReloadConfig};
+use std::env;
 
 use phf::phf_ordered_map;
 use sidebar_icon::SidebarIcon;
@@ -17,8 +19,8 @@ pub mod color_picker;
 pub mod date_converter;
 pub mod json_yaml_converter;
 pub mod number_base_converter;
-pub mod widget_entry;
 pub mod sidebar_icon;
+pub mod widget_entry;
 
 static WIDGETS: phf::OrderedMap<&str, &'static [WidgetEntry]> = phf_ordered_map! {
     "Encoder" => &[
@@ -36,13 +38,15 @@ static WIDGETS: phf::OrderedMap<&str, &'static [WidgetEntry]> = phf_ordered_map!
 
 fn main() {
     if cfg!(debug_assertions) {
+        env::set_var("RUST_BACKTRACE", "1");
+
         hot_reload_init!(HotReloadConfig::new()
             .with_paths(&["src", "style", "scss"])
             .with_rebuild_command("cargo run"));
     }
     // launch the dioxus app in a webview
     dioxus_desktop::launch_cfg(
-        app,
+        App,
         DesktopConfig::default()
             .with_custom_index(
                 r#"
@@ -89,39 +93,17 @@ fn main() {
     );
 }
 
-fn app(cx: Scope) -> Element {
+fn App(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "container-fluid",
             Router {
-                div {
-                    class: "sidebar-list",
-                    div {
-                        class: "accordion",
-                        sidebar_list_item {
-                            widget_entry: HOME_PAGE_WIDGET_ENTRY,
-                            icon: (HOME_PAGE_WIDGET_ENTRY.icon)(cx)
-                        }
-                        for widget_type in WIDGETS.keys() {
-                            div {
-                                accordion::accordion {
-                                    title: *widget_type,
-                                    for widget_entry in WIDGETS.get(widget_type).unwrap() {
-                                        sidebar_list_item {
-                                            widget_entry: *widget_entry,
-                                            icon: (widget_entry.icon)(cx)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                Sidebar {}
                 div {
                     class: "widget-view",
                     Route {
                         to: HOME_PAGE_WIDGET_ENTRY.path,
-                        widget_view {
+                        WidgetView {
                             title: HOME_PAGE_WIDGET_ENTRY.title,
                             children: (HOME_PAGE_WIDGET_ENTRY.function)(cx)
                         }
@@ -132,7 +114,7 @@ fn app(cx: Scope) -> Element {
                             for widget_entry in WIDGETS.get(widget_type).unwrap() {
                                 Route {
                                     to: widget_entry.path,
-                                    widget_view {
+                                    WidgetView {
                                         title: widget_entry.title,
                                         children: (widget_entry.function)(cx)
                                     }
@@ -147,8 +129,43 @@ fn app(cx: Scope) -> Element {
     })
 }
 
+fn Sidebar(cx: Scope) -> Element {
+    cx.render(rsx! {
+        div {
+            class: "sidebar",
+            div {
+                class: "sidebar-list",
+                div {
+                    class: "accordion",
+                    SidebarListItem {
+                        widget_entry: HOME_PAGE_WIDGET_ENTRY,
+                        icon: (HOME_PAGE_WIDGET_ENTRY.icon)(cx)
+                    }
+                    for widget_type in WIDGETS.keys() {
+                        div {
+                            accordion::Accordion {
+                                title: *widget_type,
+                                is_open: true,
+                                for widget_entry in WIDGETS.get(widget_type).unwrap() {
+                                    SidebarListItem {
+                                        widget_entry: *widget_entry,
+                                        icon: (widget_entry.icon)(cx)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            div {
+                class: "vr"
+            }
+        }
+    })
+}
+
 #[inline_props]
-fn widget_view<'a>(cx: Scope<'a>, children: Element<'a>, title: &'a str) -> Element {
+fn WidgetView<'a>(cx: Scope<'a>, children: Element<'a>, title: &'a str) -> Element {
     cx.render(rsx! {
         h3 {
             class: "widget-title",
@@ -162,7 +179,7 @@ fn widget_view<'a>(cx: Scope<'a>, children: Element<'a>, title: &'a str) -> Elem
 }
 
 #[inline_props]
-fn sidebar_list_item<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element<'a>) -> Element {
+fn SidebarListItem<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element<'a>) -> Element {
     let route = use_route(cx);
 
     let active_str = if route.url().path() == widget_entry.path {
@@ -173,7 +190,7 @@ fn sidebar_list_item<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element
 
     cx.render(rsx! {
         Link {
-            class: "btn",
+            class: "btn {active_str}",
             to: widget_entry.path
             icon
             widget_entry.short_title
@@ -186,11 +203,11 @@ static HOME_PAGE_WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     short_title: "Home",
     description: "Home page",
     path: "/home",
-    function: home_page,
+    function: HomePage,
     icon: |cx| HOME_SIDEBAR_ICON.sidebar_icon(cx),
 };
 
-fn home_page(cx: Scope) -> Element {
+fn HomePage(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             class: "home-page",
@@ -223,12 +240,3 @@ fn home_page(cx: Scope) -> Element {
 const HOME_SIDEBAR_ICON: SidebarIcon<BsHouseDoorFill> = SidebarIcon {
     icon: BsHouseDoorFill,
 };
-
-pub fn home_icon(cx: Scope) -> Element {
-    cx.render(rsx! {
-        Icon {
-            class: "home-icon",
-            icon: BsHouseDoorFill
-        }
-    })
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use dioxus_router::{use_route, Link, Redirect, Route, Router};
 use dioxus_hot_reload::{hot_reload_init, Config as HotReloadConfig};
 
 use phf::phf_ordered_map;
+use sidebar_icon::SidebarIcon;
 use widget_entry::WidgetEntry;
 
 pub mod accordion;
@@ -171,10 +172,10 @@ fn sidebar_list_item<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element
     };
 
     cx.render(rsx! {
-        icon
         Link {
             class: "btn btn-sm {active_str}",
             to: widget_entry.path
+            icon
             widget_entry.short_title
         }
     })
@@ -186,7 +187,7 @@ static HOME_PAGE_WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Home page",
     path: "/home",
     function: home_page,
-    icon: home_icon,
+    icon: |cx| HOME_SIDEBAR_ICON.sidebar_icon(cx),
 };
 
 fn home_page(cx: Scope) -> Element {
@@ -219,6 +220,9 @@ fn home_page(cx: Scope) -> Element {
     })
 }
 
+const HOME_SIDEBAR_ICON: SidebarIcon<BsHouseDoorFill> = SidebarIcon {
+    icon: BsHouseDoorFill,
+};
 
 pub fn home_icon(cx: Scope) -> Element {
     cx.render(rsx! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // import the prelude to get access to the `rsx!` macro and the `Scope` and `Element` types
 use dioxus::prelude::*;
 use dioxus_desktop::{Config as DesktopConfig, WindowBuilder};
-use dioxus_free_icons::{icons::bs_icons::{BsHouseDoorFill, BsHash}, IconShape, Icon};
+use dioxus_free_icons::{icons::bs_icons::BsHouseDoorFill, Icon};
 use dioxus_router::{use_route, Link, Redirect, Route, Router};
 
 #[cfg(debug_assertions)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // import the prelude to get access to the `rsx!` macro and the `Scope` and `Element` types
 use dioxus::prelude::*;
 use dioxus_desktop::{Config as DesktopConfig, WindowBuilder};
+use dioxus_free_icons::{icons::bs_icons::{BsHouseDoorFill, BsHash}, IconShape, Icon};
 use dioxus_router::{use_route, Link, Redirect, Route, Router};
 
 #[cfg(debug_assertions)]
@@ -16,6 +17,7 @@ pub mod date_converter;
 pub mod json_yaml_converter;
 pub mod number_base_converter;
 pub mod widget_entry;
+pub mod sidebar_icon;
 
 static WIDGETS: phf::OrderedMap<&str, &'static [WidgetEntry]> = phf_ordered_map! {
     "Encoder" => &[
@@ -96,7 +98,8 @@ fn app(cx: Scope) -> Element {
                     div {
                         class: "accordion accordion-flush flex-column ms-2 mb-2 pt-2 pe-3",
                         sidebar_list_item {
-                            widget_entry: HOME_PAGE_WIDGET_ENTRY
+                            widget_entry: HOME_PAGE_WIDGET_ENTRY,
+                            icon: (HOME_PAGE_WIDGET_ENTRY.icon)(cx)
                         }
                         for widget_type in WIDGETS.keys() {
                             div {
@@ -104,7 +107,8 @@ fn app(cx: Scope) -> Element {
                                     title: *widget_type,
                                     for widget_entry in WIDGETS.get(widget_type).unwrap() {
                                         sidebar_list_item {
-                                            widget_entry: *widget_entry
+                                            widget_entry: *widget_entry,
+                                            icon: (widget_entry.icon)(cx)
                                         }
                                     }
                                 }
@@ -157,7 +161,7 @@ fn widget_view<'a>(cx: Scope<'a>, children: Element<'a>, title: &'a str) -> Elem
 }
 
 #[inline_props]
-fn sidebar_list_item(cx: Scope, widget_entry: WidgetEntry) -> Element {
+fn sidebar_list_item<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element<'a>) -> Element {
     let route = use_route(cx);
 
     let active_str = if route.url().path() == widget_entry.path {
@@ -167,6 +171,7 @@ fn sidebar_list_item(cx: Scope, widget_entry: WidgetEntry) -> Element {
     };
 
     cx.render(rsx! {
+        icon
         Link {
             class: "btn btn-sm {active_str}",
             to: widget_entry.path
@@ -181,6 +186,7 @@ static HOME_PAGE_WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Home page",
     path: "/home",
     function: home_page,
+    icon: home_icon,
 };
 
 fn home_page(cx: Scope) -> Element {
@@ -209,6 +215,16 @@ fn home_page(cx: Scope) -> Element {
                     }
                 }
             }
+        }
+    })
+}
+
+
+pub fn home_icon(cx: Scope) -> Element {
+    cx.render(rsx! {
+        Icon {
+            class: "home-icon",
+            icon: BsHouseDoorFill
         }
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
                                 // Update theme when the preferred scheme changes
                                 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateTheme)
                             </script>
+                            <script type="text/javascript" src="../js/bootstrap.min.js"></script>
                         </body>
                     </html>
                 "#.to_string()
@@ -91,25 +92,30 @@ fn app(cx: Scope) -> Element {
             Router {
                 div {
                     class: "sidebar-list",
-                    ul {
-                        class: "nav nav-pills flex-column ms-2 mb-2 pt-2 pe-3",
+                    div {
+                        class: "list-unstyled flex-column ms-2 mb-2 pt-2 pe-3",
                         sidebar_list_item {
                             widget_entry: HOME_PAGE_WIDGET_ENTRY
                         }
                         for widget_type in WIDGETS.keys() {
                             li {
-                                details {
-                                    class: "nav-item pe-0",
-                                    open: true,
-                                    summary {//
-                                        class: "btn btn-outline-secondary",
-                                        *widget_type
-                                    }
-                                    ul {
-                                        class: "nav nav-pills",
-                                        for widget_entry in WIDGETS.get(widget_type).unwrap() {
-                                            sidebar_list_item {
-                                                widget_entry: *widget_entry
+                                button {
+                                    class: "btn btn-toggle d-inline-flex align-items-center rounded border-0",
+                                    r#type: "button",
+                                    aria_expanded: "false",
+                                    *widget_type
+                                }
+                                div {
+                                    class: "collapse show",
+                                    aria_labelledby: "flush-headingOne",
+                                    div {
+                                        class: "accordion-body",
+                                        ul {
+                                            class: "nav nav-pills",
+                                            for widget_entry in WIDGETS.get(widget_type).unwrap() {
+                                                sidebar_list_item {
+                                                    widget_entry: *widget_entry
+                                                }
                                             }
                                         }
                                     }

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
 use std::fmt;
 
-use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
+use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Number Base Converter",
@@ -10,7 +10,11 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     description: "Convert numbers between binary, octal, decimal, and hexadecimal",
     path: "/number-base-converter",
     function: number_base_converter,
-    icon: sidebar_icon::<BsHash>,
+    icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
+};
+
+const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
+    icon: BsHash,
 };
 
 pub fn number_base_converter(cx: Scope) -> Element {

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -1,14 +1,16 @@
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsHash;
 use std::fmt;
 
-use crate::widget_entry;
+use crate::{widget_entry::WidgetEntry, sidebar_icon::sidebar_icon};
 
-pub const WIDGET_ENTRY: widget_entry::WidgetEntry = widget_entry::WidgetEntry {
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Number Base Converter",
     short_title: "Number Base",
     description: "Convert numbers between binary, octal, decimal, and hexadecimal",
     path: "/number-base-converter",
     function: number_base_converter,
+    icon: sidebar_icon::<BsHash>,
 };
 
 pub fn number_base_converter(cx: Scope) -> Element {
@@ -104,48 +106,49 @@ fn format_number(number: i64, base: NumberBase, format_number: bool) -> String {
                 true => add_number_delimiters(number_binary, ' ', 4),
                 false => number_binary,
             }
-        },
+        }
         NumberBase::Octal => {
             let number_octal = format!("{:o}", number);
             match format_number {
                 true => add_number_delimiters(number_octal, ' ', 3),
                 false => number_octal,
             }
-        },
+        }
         NumberBase::Decimal => {
             let number_decimal = format!("{}", number);
             match format_number {
                 true => add_number_delimiters(number_decimal, ',', 3),
                 false => number_decimal,
             }
-        },
+        }
         NumberBase::Hexadecimal => {
             let number_hexadecimal = format!("{:X}", number);
             match format_number {
                 true => add_number_delimiters(number_hexadecimal, ' ', 4),
                 false => number_hexadecimal,
             }
-        },
+        }
     }
 }
 
 fn add_number_delimiters(number_str: String, delimiter: char, frequency: usize) -> String {
-    number_str.chars()
-    .rev()
-    .enumerate()
-    .flat_map(|(i, c)| {
-        if i != 0 && i % frequency == 0 {
-            Some(delimiter)
-        } else {
-            None
-        }
-        .into_iter()
-        .chain(std::iter::once(c))
-    })
-    .collect::<String>()
-    .chars()
-    .rev()
-    .collect::<String>()
+    number_str
+        .chars()
+        .rev()
+        .enumerate()
+        .flat_map(|(i, c)| {
+            if i != 0 && i % frequency == 0 {
+                Some(delimiter)
+            } else {
+                None
+            }
+            .into_iter()
+            .chain(std::iter::once(c))
+        })
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>()
 }
 
 fn sanitize_string(string: String) -> String {

--- a/src/number_base_converter.rs
+++ b/src/number_base_converter.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::bs_icons::BsHash;
+use dioxus_free_icons::icons::bs_icons::Bs123;
 use std::fmt;
 
 use crate::{widget_entry::WidgetEntry, sidebar_icon::SidebarIcon};
@@ -13,8 +13,8 @@ pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     icon: move |cx| SIDEBAR_ICON.sidebar_icon(cx),
 };
 
-const SIDEBAR_ICON: SidebarIcon<BsHash> = SidebarIcon {
-    icon: BsHash,
+const SIDEBAR_ICON: SidebarIcon<Bs123> = SidebarIcon {
+    icon: Bs123,
 };
 
 pub fn number_base_converter(cx: Scope) -> Element {

--- a/src/sidebar_icon.rs
+++ b/src/sidebar_icon.rs
@@ -1,0 +1,17 @@
+use dioxus::prelude::*;
+use dioxus_free_icons::{Icon, IconProps, IconShape};
+
+pub fn sidebar_icon<'a, T: IconShape>(cx: Scope) -> Element {
+    let icon_cx = Scoped::<'a, IconProps<'a, T>> {
+        scope: cx,
+        props: &IconProps::<'a, T> {
+            width: 20,
+            height: 20,
+            fill: "currentColor",
+            class: "sidebar-icon",
+            title: "x",
+            icon: todo!(),
+        }
+    };
+    Icon::<T>(&icon_cx)
+}

--- a/src/sidebar_icon.rs
+++ b/src/sidebar_icon.rs
@@ -9,6 +9,7 @@ impl<T: IconShape + Copy> SidebarIcon<T> {
     pub fn sidebar_icon<'a>(&'a self, cx: Scope<'a>) -> Element<'a> {
         cx.render(rsx! {
             Icon::<T> {
+                class: "sidebar-icon",
                 icon: self.icon,
             }
         })

--- a/src/sidebar_icon.rs
+++ b/src/sidebar_icon.rs
@@ -1,17 +1,16 @@
 use dioxus::prelude::*;
-use dioxus_free_icons::{Icon, IconProps, IconShape};
+use dioxus_free_icons::{Icon, IconShape};
 
-pub fn sidebar_icon<'a, T: IconShape>(cx: Scope) -> Element {
-    let icon_cx = Scoped::<'a, IconProps<'a, T>> {
-        scope: cx,
-        props: &IconProps::<'a, T> {
-            width: 20,
-            height: 20,
-            fill: "currentColor",
-            class: "sidebar-icon",
-            title: "x",
-            icon: todo!(),
-        }
-    };
-    Icon::<T>(&icon_cx)
+pub struct SidebarIcon<T: IconShape + Copy> {
+    pub(crate) icon: T,
+}
+
+impl<T: IconShape + Copy> SidebarIcon<T> {
+    pub fn sidebar_icon<'a>(&'a self, cx: Scope<'a>) -> Element<'a> {
+        cx.render(rsx! {
+            Icon::<T> {
+                icon: self.icon,
+            }
+        })
+    }
 }

--- a/src/widget_entry.rs
+++ b/src/widget_entry.rs
@@ -7,4 +7,5 @@ pub struct WidgetEntry {
     pub description: &'static str,
     pub path: &'static str,
     pub function: fn(cx: Scope) -> Element,
+    pub icon: fn(cx: Scope) -> Element,
 }


### PR DESCRIPTION
Adds a new Accordion element for collapsable content with more control than details.

Refactors more of the stylesheets to Sass.

Adds Bootstrap icons for the sidebar entries.