### PR TITLE
Adding basic date/time conversion widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ grass = "0.12.4"
 zip-extract = "0.1.2"
 
 [dev-dependencies]
-dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
 
 [dependencies]
 base64 = "0.21.2"
 chrono = "0.4.26"
 chrono-tz = "0.8.3"
-dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
-dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
-dioxus-free-icons = { version = "0.6.0", features = ["bootstrap"] }
-dioxus-interpreter-js = "0.3.3"
-dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
+dioxus-interpreter-js = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
 phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a752
 dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
 dioxus-interpreter-js = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+num-traits = "0.2.15"
 phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ dioxus-hot-reload = "0.1.1"
 
 [dependencies]
 base64 = "0.21.2"
+chrono = "0.4.26"
+chrono-tz = "0.8.3"
 dioxus = "0.3.2"
 dioxus-desktop = "0.3.0"
-dioxus-router = "0.3.0"
-dioxus-interpreter-js = "0.3.3"
-phf = { version = "0.11.1", features = ["macros"] }
 dioxus-free-icons = { version = "0.6.0", features = ["bootstrap"] }
+dioxus-interpreter-js = "0.3.3"
+dioxus-router = "0.3.0"
+phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"
 strum_macros = "0.25.1"
-chrono-tz = "0.8.3"
-chrono = "0.4.26"
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ dioxus-free-icons = { version = "0.6.0", features = ["bootstrap"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"
 strum_macros = "0.25.1"
+chrono-tz = "0.8.3"
+chrono = "0.4.26"
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ grass = "0.12.4"
 zip-extract = "0.1.2"
 
 [dev-dependencies]
-dioxus-hot-reload = "0.1.1"
+dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 
 [dependencies]
 base64 = "0.21.2"
 chrono = "0.4.26"
 chrono-tz = "0.8.3"
-dioxus = "0.3.2"
-dioxus-desktop = "0.3.0"
+dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-free-icons = { version = "0.6.0", features = ["bootstrap"] }
 dioxus-interpreter-js = "0.3.3"
-dioxus-router = "0.3.0"
+dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ grass = "0.12.4"
 zip-extract = "0.1.2"
 
 [dev-dependencies]
-dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 
 [dependencies]
 base64 = "0.21.2"
 chrono = "0.4.26"
 chrono-tz = "0.8.3"
-dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
-dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
-dioxus-interpreter-js = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
-dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"}
+dioxus-interpreter-js = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
 strum = "0.25.0"

--- a/scss/components/components.scss
+++ b/scss/components/components.scss
@@ -1,5 +1,6 @@
 @import "textarea_form.scss";
 @import "text_input.scss";
+@import "number_input.scss";
 @import "select_form.scss";
 @import "switch.scss";
 @import "card.scss";

--- a/scss/components/number_input.scss
+++ b/scss/components/number_input.scss
@@ -1,0 +1,7 @@
+div.number-input {
+    @extend .form-floating, .mb-3;
+    input {
+      @extend .form-control;
+    }
+  }
+  

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -24,4 +24,5 @@ body {
 @import "components/components.scss";
 @import "pages/home_page.scss";
 @import "pages/base64_encoder.scss";
+@import "pages/date_converter.scss";
 @import "pages/qr_code_generator.scss";

--- a/scss/pages/date_converter.scss
+++ b/scss/pages/date_converter.scss
@@ -2,9 +2,24 @@
   margin-bottom: 1em;
 }
 
-.ymd-selectors {
-  @extend .flex-row, .gx-1, .d-flex;
-  .number-input {
-    @extend .flex-column;
+.selectors-wrapper {
+  @extend .flex-row, .d-flex;
+
+  flex-wrap: nowrap;
+}
+
+@media screen and (max-width: 768px) {
+  .selectors-wrapper {
+    flex-wrap: wrap;
+  }
+}
+
+.selectors {
+  @extend .flex-column;
+  .selectors-inner {
+    @extend .flex-row, .d-flex, .flex-nowrap;
+    .number-input {
+      @extend .flex-column, .flex-fill, .me-2;
+    }
   }
 }

--- a/scss/pages/date_converter.scss
+++ b/scss/pages/date_converter.scss
@@ -1,0 +1,10 @@
+.select-form {
+  margin-bottom: 1em;
+}
+
+.ymd-selectors {
+    @extend .flex-row, .gx-1, .d-flex;
+    .number-input {
+        @extend .flex-column;
+      }
+}

--- a/scss/pages/date_converter.scss
+++ b/scss/pages/date_converter.scss
@@ -3,8 +3,8 @@
 }
 
 .ymd-selectors {
-    @extend .flex-row, .gx-1, .d-flex;
-    .number-input {
-        @extend .flex-column;
-      }
+  @extend .flex-row, .gx-1, .d-flex;
+  .number-input {
+    @extend .flex-column;
+  }
 }

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
 use dioxus::prelude::*;
-
+use num_traits::PrimInt;
 use strum::IntoEnumIterator;
 
 pub trait SelectFormEnum:
@@ -123,6 +123,35 @@ pub fn TextInput<'a>(
                     None => {}
                 },
                 readonly: readonly
+            }
+            label {
+                r#for: "{label}",
+                *label
+            }
+        }
+    })
+}
+
+#[inline_props]
+pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
+    cx: Scope<'a>,
+    class: Option<&'a str>,
+    value: T,
+    label: &'a str,
+    onchange: EventHandler<'a, T>,
+) -> Element<'a>
+{
+    cx.render(rsx! {
+        div {
+            class: "number-input {class.unwrap_or_default()}",
+            input {
+                r#type: "number",
+                value: "{value}",
+                id: "{label}",
+                onchange: move |event| {
+                    let value = event.value.parse::<T>().unwrap_or_default();
+                    onchange.call(value);
+                }
             }
             label {
                 r#for: "{label}",

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -7,7 +7,7 @@ use dioxus::prelude::*;
 use strum::IntoEnumIterator;
 
 pub trait SelectFormEnum:
-    IntoEnumIterator + Into<&'static str> + FromStr + Default + Debug + Display + Copy + Clone
+    IntoEnumIterator + Into<&'static str> + FromStr + Default + Debug + Display + Copy + Clone + PartialEq
 {
 }
 
@@ -24,6 +24,7 @@ pub fn SelectForm<'a, T: SelectFormEnum>(cx: Scope<'a, SelectFormProps<'a, T>>) 
                 for enumInst in T::iter() {
                     option {
                         value: "{enumInst.into()}",
+                        selected: enumInst == cx.props.value,
                         "{enumInst.into()}"
                     }
                 }
@@ -39,6 +40,7 @@ pub fn SelectForm<'a, T: SelectFormEnum>(cx: Scope<'a, SelectFormProps<'a, T>>) 
 #[derive(Props)]
 pub struct SelectFormProps<'a, T: SelectFormEnum> {
     label: &'a str,
+    value: T,
     oninput: EventHandler<'a, T>,
 }
 

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -7,7 +7,15 @@ use dioxus::prelude::*;
 use strum::IntoEnumIterator;
 
 pub trait SelectFormEnum:
-    IntoEnumIterator + Into<&'static str> + FromStr + Default + Debug + Display + Copy + Clone + PartialEq
+    IntoEnumIterator
+    + Into<&'static str>
+    + FromStr
+    + Default
+    + Debug
+    + Display
+    + Copy
+    + Clone
+    + PartialEq
 {
 }
 

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -98,15 +98,21 @@ pub fn TextInput<'a>(
     cx: Scope<'a>,
     value: &'a str,
     label: &'a str,
-    oninput: EventHandler<'a, Event<FormData>>,
+    oninput: Option<EventHandler<'a, Event<FormData>>>,
+    readonly: Option<bool>,
 ) -> Element<'a> {
+    let readonly = readonly.unwrap_or(false);
     cx.render(rsx! {
         div {
             class: "text-input",
             input {
                 r#type: "text",
                 value: "{value}",
-                oninput: move |event| oninput.call(event)
+                oninput: move |event| match oninput {
+                    Some(oninput) => oninput.call(event),
+                    None => {}
+                },
+                readonly: readonly
             }
             label {
                 r#for: "{label}",

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -109,6 +109,7 @@ pub fn TextInput<'a>(
     value: &'a str,
     label: &'a str,
     oninput: Option<EventHandler<'a, Event<FormData>>>,
+    onchange: Option<EventHandler<'a, Event<FormData>>>,
     readonly: Option<bool>,
 ) -> Element<'a> {
     let readonly = readonly.unwrap_or(false);
@@ -120,6 +121,10 @@ pub fn TextInput<'a>(
                 value: "{value}",
                 oninput: move |event| match oninput {
                     Some(oninput) => oninput.call(event),
+                    None => {}
+                },
+                onchange: move |event| match onchange {
+                    Some(onchange) => onchange.call(event),
                     None => {}
                 },
                 readonly: readonly

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -144,8 +144,7 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
     value: T,
     label: &'a str,
     onchange: EventHandler<'a, T>,
-) -> Element<'a>
-{
+) -> Element<'a> {
     cx.render(rsx! {
         div {
             class: "number-input {class.unwrap_or_default()}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn SidebarListItem<'a>(cx: Scope<'a>, widget_entry: WidgetEntry, icon: Element<'
     cx.render(rsx! {
         Link {
             class: "btn {active_str}",
-            to: widget_entry.path
+            to: widget_entry.path,
             icon
             widget_entry.short_title
         }

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -43,13 +43,14 @@ pub fn date_converter(cx: Scope) -> Element {
                 label: "Time Zone",
                 oninput: move |tz: DcTimeZone| {
                     date_state.write().time_zone = tz;
-                }
+                },
                 value: date_state.read().time_zone,
             }
             TextInput {
                 label: "Date",
                 value: "{date_time_str}",
-                readonly: true
+                oninput: |_| {},
+                readonly: true,
             }
         }
     })

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,11 +1,14 @@
 use std::{fmt::Display, str::FromStr};
 
+use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
 use strum::IntoEnumIterator;
-use chrono_tz::{TZ_VARIANTS, Tz, ParseError};
 
-use crate::{widget_entry::{WidgetEntry, WidgetIcon}, components::inputs::{SelectFormEnum, SelectForm}};
+use crate::{
+    components::inputs::{SelectForm, SelectFormEnum},
+    widget_entry::{WidgetEntry, WidgetIcon},
+};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Date Converter",
@@ -61,7 +64,11 @@ impl FromStr for TimeZone {
 
 impl IntoEnumIterator for TimeZone {
     fn iter() -> Self::Iterator {
-        TZ_VARIANTS.iter().map(|tz| Self::Base(*tz)).collect::<Vec<_>>().into_iter()
+        TZ_VARIANTS
+            .iter()
+            .map(|tz| Self::Base(*tz))
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     type Iterator = std::vec::IntoIter<Self>;
@@ -74,6 +81,5 @@ impl From<TimeZone> for &'static str {
         }
     }
 }
-
 
 impl SelectFormEnum for TimeZone {}

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -62,59 +62,71 @@ pub fn date_converter(cx: Scope) -> Element {
                 }
             }
             div {
-                class: "ymd-selectors",
-                NumberInput::<i32> {
-                    class: "year",
-                    label: "Year",
-                    value: date_state.read().local_datetime().year(),
-                    onchange: move |year| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_year(year).unwrap_or(datetime));
+                class: "selectors-wrapper",
+                div {
+                    class: "ymd selectors",
+                    div {
+                        class: "selectors-inner",
+                        NumberInput::<i32> {
+                            class: "year",
+                            label: "Year",
+                            value: date_state.read().local_datetime().year(),
+                            onchange: move |year| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_year(year).unwrap_or(datetime));
+                            }
+                        }
+                        NumberInput::<u32> {
+                            class: "month",
+                            label: "Month",
+                            value: date_state.read().local_datetime().month(),
+                            onchange: move |month| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_month(month).unwrap_or(datetime));
+                            }
+                        }
+                        NumberInput::<u32> {
+                            class: "day",
+                            label: "Day",
+                            value: date_state.read().local_datetime().day(),
+                            onchange: move |day| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_day(day).unwrap_or(datetime));
+                            }
+                        }
                     }
                 }
-                NumberInput::<u32> {
-                    class: "month",
-                    label: "Month",
-                    value: date_state.read().local_datetime().month(),
-                    onchange: move |month| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_month(month).unwrap_or(datetime));
-                    }
-                }
-                NumberInput::<u32> {
-                    class: "day",
-                    label: "Day",
-                    value: date_state.read().local_datetime().day(),
-                    onchange: move |day| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_day(day).unwrap_or(datetime));
-                    }
-                }
-                NumberInput::<u32> {
-                    class: "hour",
-                    label: "Hour",
-                    value: date_state.read().local_datetime().hour(),
-                    onchange: move |hour| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_hour(hour).unwrap_or(datetime));
-                    }
-                }
-                NumberInput::<u32> {
-                    class: "minute",
-                    label: "Minute",
-                    value: date_state.read().local_datetime().minute(),
-                    onchange: move |minute| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_minute(minute).unwrap_or(datetime));
-                    }
-                }
-                NumberInput::<u32> {
-                    class: "second",
-                    label: "Second",
-                    value: date_state.read().local_datetime().second(),
-                    onchange: move |second| {
-                        let datetime = date_state.read().local_datetime();
-                        date_state.write().set_local_datetime(datetime.with_second(second).unwrap_or(datetime));
+                div {
+                    class: "hms selectors",
+                    div {
+                        class: "selectors-inner",
+                        NumberInput::<u32> {
+                            class: "hour",
+                            label: "Hour",
+                            value: date_state.read().local_datetime().hour(),
+                            onchange: move |hour| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_hour(hour).unwrap_or(datetime));
+                            }
+                        }
+                        NumberInput::<u32> {
+                            class: "minute",
+                            label: "Minute",
+                            value: date_state.read().local_datetime().minute(),
+                            onchange: move |minute| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_minute(minute).unwrap_or(datetime));
+                            }
+                        }
+                        NumberInput::<u32> {
+                            class: "second",
+                            label: "Second",
+                            value: date_state.read().local_datetime().second(),
+                            onchange: move |second| {
+                                let datetime = date_state.read().local_datetime();
+                                date_state.write().set_local_datetime(datetime.with_second(second).unwrap_or(datetime));
+                            }
+                        }
                     }
                 }
             }

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -49,7 +49,6 @@ pub fn date_converter(cx: Scope) -> Element {
             TextInput {
                 label: "Date",
                 value: "{date_time_str}",
-                oninput: move |_| {}
                 readonly: true
             }
         }

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -76,9 +76,7 @@ impl Default for DcTimeZone {
 
 impl Display for DcTimeZone {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Base(tz) => write!(f, "{}", tz),
-        }
+        write!(f, "{}", self.inner())
     }
 }
 
@@ -110,9 +108,7 @@ impl IntoEnumIterator for DcTimeZone {
 
 impl From<DcTimeZone> for &'static str {
     fn from(val: DcTimeZone) -> Self {
-        match val {
-            DcTimeZone::Base(tz) => tz.name(),
-        }
+        val.inner().name()
     }
 }
 

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -42,7 +42,6 @@ pub fn date_converter(cx: Scope) -> Element {
             SelectForm::<DcTimeZone> {
                 label: "Time Zone",
                 oninput: move |tz: DcTimeZone| {
-                    println!("Time Zone: {}", tz);
                     date_state.write().time_zone = tz;
                 }
                 value: date_state.read().time_zone,

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{Datelike, DateTime, NaiveDateTime, TimeZone, Timelike, Utc};
+use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc};
 use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
@@ -29,10 +29,7 @@ pub fn date_converter(cx: Scope) -> Element {
     });
     let date_state = use_shared_state::<DateConverterState>(cx).unwrap();
 
-    let date_time_str = date_state
-        .read()
-        .local_datetime()
-        .to_string();
+    let date_time_str = date_state.read().local_datetime().to_string();
 
     let unix_time_str = date_state.read().time.timestamp().to_string();
 

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -4,7 +4,6 @@ use chrono::{NaiveDateTime, TimeZone, Utc, Datelike, Timelike};
 use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
-use num_traits::Num;
 use strum::IntoEnumIterator;
 
 use crate::{

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -40,6 +40,7 @@ pub fn date_converter(cx: Scope) -> Element {
                     println!("Time Zone: {}", tz);
                     date_state.write().time_zone = tz;
                 }
+                value: date_state.read().time_zone,
             }
             TextInput {
                 label: "Date",
@@ -57,7 +58,7 @@ struct DateConverterState {
     time: NaiveDateTime,
 }
 
-#[derive(Copy, Clone, Debug, Hash)]
+#[derive(Copy, Clone, Debug)]
 enum DcTimeZone {
     Base(Tz),
 }
@@ -82,6 +83,12 @@ impl FromStr for DcTimeZone {
     }
 
     type Err = ParseError;
+}
+
+impl PartialEq for DcTimeZone {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner() == other.inner()
+    }
 }
 
 impl IntoEnumIterator for DcTimeZone {

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,13 +1,14 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{NaiveDateTime, TimeZone, Utc};
+use chrono::{NaiveDateTime, TimeZone, Utc, Datelike, Timelike};
 use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
+use num_traits::Num;
 use strum::IntoEnumIterator;
 
 use crate::{
-    components::inputs::{SelectForm, SelectFormEnum, TextInput},
+    components::inputs::{SelectForm, SelectFormEnum, TextInput, NumberInput},
     widget_entry::{WidgetEntry, WidgetIcon},
 };
 
@@ -51,6 +52,63 @@ pub fn date_converter(cx: Scope) -> Element {
                 value: "{date_time_str}",
                 oninput: |_| {},
                 readonly: true,
+            }
+            div {
+                class: "ymd-selectors",
+                NumberInput::<i32> {
+                    class: "year",
+                    label: "Year",
+                    value: date_state.read().time.year(),
+                    onchange: move |year| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_year(year).unwrap_or(datetime);
+                    }
+                }
+                NumberInput::<u32> {
+                    class: "month",
+                    label: "Month",
+                    value: date_state.read().time.month(),
+                    onchange: move |month| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_month(month).unwrap_or(datetime);
+                    }
+                }
+                NumberInput::<u32> {
+                    class: "day",
+                    label: "Day",
+                    value: date_state.read().time.day(),
+                    onchange: move |day| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_day(day).unwrap_or(datetime);
+                    }
+                }
+                NumberInput::<u32> {
+                    class: "hour",
+                    label: "Hour",
+                    value: date_state.read().time.hour(),
+                    onchange: move |hour| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_hour(hour).unwrap_or(datetime);
+                    }
+                }
+                NumberInput::<u32> {
+                    class: "minute",
+                    label: "Minute",
+                    value: date_state.read().time.minute(),
+                    onchange: move |minute| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_minute(minute).unwrap_or(datetime);
+                    }
+                }
+                NumberInput::<u32> {
+                    class: "second",
+                    label: "Second",
+                    value: date_state.read().time.second(),
+                    onchange: move |second| {
+                        let datetime = date_state.read().time;
+                        date_state.write().time = datetime.with_second(second).unwrap_or(datetime);
+                    }
+                }
             }
         }
     })

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{TimeZone, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, TimeZone, Utc};
 use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
@@ -29,7 +29,12 @@ pub fn date_converter(cx: Scope) -> Element {
     });
     let date_state = use_shared_state::<DateConverterState>(cx).unwrap();
 
-    let date_time_str = date_state.read().time_zone.inner().from_utc_datetime(&date_state.read().time).to_string();
+    let date_time_str = date_state
+        .read()
+        .time_zone
+        .inner()
+        .from_utc_datetime(&date_state.read().time)
+        .to_string();
 
     cx.render(rsx! {
         div {

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,7 +1,11 @@
+use std::{fmt::Display, str::FromStr};
+
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
+use strum::IntoEnumIterator;
+use chrono_tz::{TZ_VARIANTS, Tz, ParseError};
 
-use crate::widget_entry::{WidgetEntry, WidgetIcon};
+use crate::{widget_entry::{WidgetEntry, WidgetIcon}, components::inputs::{SelectFormEnum, SelectForm}};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Date Converter",
@@ -17,8 +21,59 @@ const ICON: WidgetIcon<BsClock> = WidgetIcon { icon: BsClock };
 pub fn date_converter(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
-            class: "date-converter"
-            
+            class: "date-converter",
+            SelectForm::<TimeZone> {
+                label: "Time Zone",
+                oninput: move |tz: TimeZone| {
+                    println!("Time Zone: {}", tz);
+                }
+            }
         }
     })
 }
+
+#[derive(Copy, Clone, Debug, Hash)]
+enum TimeZone {
+    Base(Tz),
+}
+
+impl Default for TimeZone {
+    fn default() -> Self {
+        Self::Base(Tz::UTC)
+    }
+}
+
+impl Display for TimeZone {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Base(tz) => write!(f, "{}", tz),
+        }
+    }
+}
+
+impl FromStr for TimeZone {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::Base(Tz::from_str(s)?))
+    }
+
+    type Err = ParseError;
+}
+
+impl IntoEnumIterator for TimeZone {
+    fn iter() -> Self::Iterator {
+        TZ_VARIANTS.iter().map(|tz| Self::Base(*tz)).collect::<Vec<_>>().into_iter()
+    }
+
+    type Iterator = std::vec::IntoIter<Self>;
+}
+
+impl From<TimeZone> for &'static str {
+    fn from(val: TimeZone) -> Self {
+        match val {
+            TimeZone::Base(tz) => tz.name(),
+        }
+    }
+}
+
+
+impl SelectFormEnum for TimeZone {}

--- a/src/pages/number_base_converter.rs
+++ b/src/pages/number_base_converter.rs
@@ -2,8 +2,8 @@ use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::Bs123;
 use std::fmt;
 
-use crate::widget_entry::{WidgetEntry, WidgetIcon};
 use crate::components::inputs::{SwitchInput, TextInput};
+use crate::widget_entry::{WidgetEntry, WidgetIcon};
 
 pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
     title: "Number Base Converter",

--- a/src/pages/qr_code_generator.rs
+++ b/src/pages/qr_code_generator.rs
@@ -45,6 +45,7 @@ pub fn qr_code_generator(cx: Scope) -> Element {
                 oninput: |ecc: Ecc| {
                     qr_code_error_correction.set(ecc);
                 }
+                value: *qr_code_error_correction.get(),
             }
             TextAreaForm {
                 label: "Input",
@@ -68,7 +69,7 @@ pub fn qr_code_generator(cx: Scope) -> Element {
     })
 }
 
-#[derive(Copy, Clone, Default, Debug, Display, EnumIter, EnumString, Hash, IntoStaticStr)]
+#[derive(Copy, Clone, Default, Debug, Display, EnumIter, EnumString, Hash, IntoStaticStr, PartialEq)]
 enum Ecc {
     #[default]
     Low,

--- a/src/pages/qr_code_generator.rs
+++ b/src/pages/qr_code_generator.rs
@@ -69,7 +69,9 @@ pub fn qr_code_generator(cx: Scope) -> Element {
     })
 }
 
-#[derive(Copy, Clone, Default, Debug, Display, EnumIter, EnumString, Hash, IntoStaticStr, PartialEq)]
+#[derive(
+    Copy, Clone, Default, Debug, Display, EnumIter, EnumString, Hash, IntoStaticStr, PartialEq,
+)]
 enum Ecc {
     #[default]
     Low,

--- a/src/pages/qr_code_generator.rs
+++ b/src/pages/qr_code_generator.rs
@@ -44,7 +44,7 @@ pub fn qr_code_generator(cx: Scope) -> Element {
                 label: "Error Correction Level",
                 oninput: |ecc: Ecc| {
                     qr_code_error_correction.set(ecc);
-                }
+                },
                 value: *qr_code_error_correction.get(),
             }
             TextAreaForm {
@@ -52,7 +52,7 @@ pub fn qr_code_generator(cx: Scope) -> Element {
                 value: qr_code_value,
                 oninput: |event: Event<FormData>| {
                     qr_code_value.set(event.value.clone());
-                }
+                },
             }
 
             div {


### PR DESCRIPTION
Adding a basic widget for date/time conversion. I am using the [chrono_tz crate](https://docs.rs/chrono-tz/latest/chrono_tz/index.html) to get the list of possible IANA timezones. I am not super happy with the ordering of these timezones, but there's >500 entries in the DB. I may work out some sort of custom selector later.

Adding an onchange event attribute for TextInput, adding a new NumberInput component.

Fixing a regression in the SelectForm dropdown that prevented the display value from persisting between page changes.