### PR TITLE
Replace NumberInput slider with custom buttons

### DIFF
--- a/scss/components/number_input.scss
+++ b/scss/components/number_input.scss
@@ -1,7 +1,13 @@
 div.number-input {
-    @extend .form-floating, .mb-3;
-    input {
-      @extend .form-control;
-    }
+  @extend .form-floating, .mb-3;
+  input {
+    @extend .form-control;
   }
-  
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  input[type="number"] {
+    -moz-appearance: textfield;
+  }
+}

--- a/scss/components/number_input.scss
+++ b/scss/components/number_input.scss
@@ -1,7 +1,17 @@
 div.number-input {
-  @extend .form-floating, .mb-3;
-  input {
-    @extend .form-control;
+  @extend .mb-3;
+  .input-and-label {
+    @extend .form-floating;
+    input {
+      @extend .form-control, .h-100;
+    }
+  }
+  button {
+    @extend .btn, .btn-outline-secondary, .p-0;
+
+    &:hover {
+      @extend .btn-outline-primary;
+    }
   }
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;

--- a/scss/pages/date_converter.scss
+++ b/scss/pages/date_converter.scss
@@ -8,7 +8,7 @@
   flex-wrap: nowrap;
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 835px) {
   .selectors-wrapper {
     flex-wrap: wrap;
   }

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -3,6 +3,10 @@ use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
 use dioxus::prelude::*;
+use dioxus_free_icons::{
+    icons::bs_icons::{BsDash, BsPlus},
+    Icon,
+};
 use num_traits::PrimInt;
 use strum::IntoEnumIterator;
 
@@ -163,40 +167,52 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
             class: "number-input {class.unwrap_or_default()}",
             div {
                 class: "input-group",
-                input {
-                    r#type: "number",
-                    value: "{value}",
-                    id: "{label}",
-                    onchange: move |event| {
-                        if let Ok(value) = event.value.parse::<T>() {
-                            onchange.call(value);
+                div {
+                    class: "input-and-label",
+                    input {
+                        class: "form-control",
+                        r#type: "number",
+                        value: "{value}",
+                        id: "{label}",
+                        onchange: move |event| {
+                            if let Ok(value) = event.value.parse::<T>() {
+                                onchange.call(value);
+                            }
                         }
+                    }
+                    label {
+                        r#for: "{label}",
+                        *label
                     }
                 }
                 div {
-                    class: "button-group",
+                    class: "btn-group-vertical input-group-text p-1",
                     button {
-                        class: "btn btn-sm btn-outline-secondary",
                         onclick: move |_| {
                             if let Some(value) = value.checked_add(&T::one()) {
                                 onchange.call(value);
                             };
                         },
-                        "+"
+                        Icon {
+                            icon: BsPlus,
+                            class: "button-icon",
+                            height: 15,
+                            width: 15,
+                        }
                     }
                     button {
-                        class: "btn btn-sm btn-outline-secondary",
                         onclick: move |_| {
                             if let Some(value) = value.checked_sub(&T::one()) {
                                 onchange.call(value);
                             };
                         },
-                        "-"
+                        Icon {
+                            icon: BsDash,
+                            class: "button-icon",
+                            height: 15,
+                            width: 15,
+                        }
                     }
-                }
-                label {
-                    r#for: "{label}",
-                    *label
                 }
             }
         }

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -27,7 +27,9 @@ pub fn SelectForm<'a, T: SelectFormEnum>(cx: Scope<'a, SelectFormProps<'a, T>>) 
                 id: "{cx.props.label}",
                 aria_label: "{cx.props.label}",
                 oninput: move |event| {
-                    cx.props.oninput.call(T::from_str(&event.value).unwrap_or_default());
+                    if let Ok(value) = T::from_str(&event.value) {
+                        cx.props.oninput.call(value);
+                    }
                 },
                 for enumInst in T::iter() {
                     option {
@@ -159,18 +161,43 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
     cx.render(rsx! {
         div {
             class: "number-input {class.unwrap_or_default()}",
-            input {
-                r#type: "number",
-                value: "{value}",
-                id: "{label}",
-                onchange: move |event| {
-                    let value = event.value.parse::<T>().unwrap_or_default();
-                    onchange.call(value);
+            div {
+                class: "input-group",
+                input {
+                    r#type: "number",
+                    value: "{value}",
+                    id: "{label}",
+                    onchange: move |event| {
+                        if let Ok(value) = event.value.parse::<T>() {
+                            onchange.call(value);
+                        }
+                    }
                 }
-            }
-            label {
-                r#for: "{label}",
-                *label
+                div {
+                    class: "button-group",
+                    button {
+                        class: "btn btn-sm btn-outline-secondary",
+                        onclick: move |_| {
+                            if let Some(value) = value.checked_add(&T::one()) {
+                                onchange.call(value);
+                            };
+                        },
+                        "+"
+                    }
+                    button {
+                        class: "btn btn-sm btn-outline-secondary",
+                        onclick: move |_| {
+                            if let Some(value) = value.checked_sub(&T::one()) {
+                                onchange.call(value);
+                            };
+                        },
+                        "-"
+                    }
+                }
+                label {
+                    r#for: "{label}",
+                    *label
+                }
             }
         }
     })


### PR DESCRIPTION
Replacing the webkit-default slider for number input with a cross-platform button group.

Events will no longer propagate if a number input is invalid. The same for select form input, though that should be an unreachable case unless someone modifies the html.