### PR TITLE
Adding hash generator widget, improved use_ref handling, better base64 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,21 @@ zip-extract = "0.1.2"
 dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 
 [dependencies]
-base64 = "0.21.2"
+base64ct = { version = "1.6.0", features = ["alloc"] }
 chrono = "0.4.26"
 chrono-tz = "0.8.3"
+digest = "0.10.7"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
 dioxus-interpreter-js = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+md-5 = "0.10.5"
 num-traits = "0.2.15"
 phf = { version = "0.11.1", features = ["macros"] }
 qrcode-generator = "4.1.8"
+sha1 = "0.10.5"
+sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }

--- a/src/pages/base64_encoder.rs
+++ b/src/pages/base64_encoder.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose, Engine as _};
+use base64ct::{Base64, Encoding};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsHash;
 use std::fmt;
@@ -57,12 +57,15 @@ fn encoder_input(cx: Scope, direction: Direction) -> Element {
                 match direction {
                     Direction::Encode => {
                         value_context.write().decoded_value = input_value.clone();
-                        value_context.write().encoded_value = general_purpose::STANDARD.encode(input_value);
+                        value_context.write().encoded_value = Base64::encode_string(input_value.as_bytes());
                     },
                     Direction::Decode => {
                         value_context.write().encoded_value = input_value.clone();
-                        let decode_val = general_purpose::STANDARD.decode(input_value).unwrap_or_default();
-                        value_context.write().decoded_value = String::from_utf8(decode_val).unwrap_or(NOT_STRING.to_string());
+                        let decode_val = match Base64::decode_vec(input_value.as_str()) {
+                            Ok(val) => String::from_utf8(val).unwrap_or(NOT_STRING.to_string()),
+                            Err(_) => NOT_STRING.to_string(),
+                        };
+                        value_context.write().decoded_value = decode_val;
                     },
                 };
             }

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -28,9 +28,8 @@ pub fn date_converter(cx: Scope) -> Element {
         time: Utc::now().naive_utc(),
     });
 
-    let date_time_str = date_state.read().local_datetime().to_string();
-
-    let unix_time_str = date_state.read().time.timestamp().to_string();
+    let local_datetime = date_state.with(|date_state| date_state.local_datetime());
+    let unix_time = date_state.with(|date_state| date_state.time.timestamp());
 
     cx.render(rsx! {
         div {
@@ -38,25 +37,29 @@ pub fn date_converter(cx: Scope) -> Element {
             SelectForm::<DcTimeZone> {
                 label: "Time Zone",
                 oninput: move |tz: DcTimeZone| {
-                    date_state.write().time_zone = tz;
+                    date_state.with_mut(|date_state| {
+                        date_state.time_zone = tz;
+                    });
                 },
-                value: date_state.read().time_zone,
+                value: date_state.with(|date_state| date_state.time_zone),
             }
             TextInput {
                 label: "Date",
-                value: "{date_time_str}",
+                value: "{local_datetime}",
                 readonly: true,
             }
             TextInput {
                 label: "Unix Timestamp",
-                value: "{unix_time_str}",
+                value: "{unix_time}",
                 onchange: move |event: Event<FormData>| {
                     let new_unix_time = event.value.clone();
                     if let Ok(unix_time) = i64::from_str(&new_unix_time) {
-                        date_state.write().time = match Utc.timestamp_opt(unix_time, 0) {
-                            chrono::LocalResult::Single(datetime) => datetime.naive_utc(),
-                            _ => date_state.read().time,
-                        };
+                        date_state.with_mut(|date_state| {
+                            date_state.time = match Utc.timestamp_opt(unix_time, 0) {
+                                chrono::LocalResult::Single(datetime) => datetime.naive_utc(),
+                                _ => date_state.time,
+                            };
+                        });
                     }
                 }
             }
@@ -69,28 +72,31 @@ pub fn date_converter(cx: Scope) -> Element {
                         NumberInput::<i32> {
                             class: "year",
                             label: "Year",
-                            value: date_state.read().local_datetime().year(),
+                            value: local_datetime.year(),
                             onchange: move |year| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_year(year).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_year(year).unwrap_or(local_datetime));
+                                });
                             }
                         }
                         NumberInput::<u32> {
                             class: "month",
                             label: "Month",
-                            value: date_state.read().local_datetime().month(),
+                            value: local_datetime.month(),
                             onchange: move |month| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_month(month).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_month(month).unwrap_or(local_datetime));
+                                });
                             }
                         }
                         NumberInput::<u32> {
                             class: "day",
                             label: "Day",
-                            value: date_state.read().local_datetime().day(),
+                            value: local_datetime.day(),
                             onchange: move |day| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_day(day).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_day(day).unwrap_or(local_datetime));
+                                });
                             }
                         }
                     }
@@ -102,28 +108,31 @@ pub fn date_converter(cx: Scope) -> Element {
                         NumberInput::<u32> {
                             class: "hour",
                             label: "Hour",
-                            value: date_state.read().local_datetime().hour(),
+                            value: local_datetime.hour(),
                             onchange: move |hour| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_hour(hour).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_hour(hour).unwrap_or(local_datetime));
+                                });
                             }
                         }
                         NumberInput::<u32> {
                             class: "minute",
                             label: "Minute",
-                            value: date_state.read().local_datetime().minute(),
+                            value: local_datetime.minute(),
                             onchange: move |minute| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_minute(minute).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_minute(minute).unwrap_or(local_datetime));
+                                });
                             }
                         }
                         NumberInput::<u32> {
                             class: "second",
                             label: "Second",
-                            value: date_state.read().local_datetime().second(),
+                            value: local_datetime.second(),
                             onchange: move |second| {
-                                let datetime = date_state.read().local_datetime();
-                                date_state.write().set_local_datetime(datetime.with_second(second).unwrap_or(datetime));
+                                date_state.with_mut(|date_state| {
+                                    date_state.set_local_datetime(local_datetime.with_second(second).unwrap_or(local_datetime));
+                                });
                             }
                         }
                     }

--- a/src/pages/hash_generator.rs
+++ b/src/pages/hash_generator.rs
@@ -1,0 +1,131 @@
+use digest::DynDigest;
+use dioxus::prelude::*;
+use dioxus_free_icons::icons::bs_icons::BsFingerprint;
+use std::fmt;
+
+use crate::components::inputs::{SwitchInput, TextAreaForm, TextInput};
+use crate::widget_entry::{WidgetEntry, WidgetIcon};
+
+pub const WIDGET_ENTRY: WidgetEntry = WidgetEntry {
+    title: "Hash Generator",
+    short_title: "Hash",
+    description: "Generate cryptographic hashes of strings",
+    path: "/hash-generator",
+    function: hash_generator,
+    icon: move |cx| ICON.icon(cx),
+};
+
+const ICON: WidgetIcon<BsFingerprint> = WidgetIcon {
+    icon: BsFingerprint,
+};
+
+pub fn hash_generator(cx: Scope) -> Element {
+    use_shared_state_provider(cx, || HashGeneratorState {
+        value: "".to_string(),
+        uppercase: false,
+    });
+
+    let hash_generator_state = use_shared_state::<HashGeneratorState>(cx).unwrap();
+
+    cx.render(rsx! {
+        div {
+            class: "number-base-converter",
+            SwitchInput {
+                label: "Uppercase",
+                checked: hash_generator_state.read().uppercase,
+                oninput: move |is_enabled| {
+                    hash_generator_state.write().uppercase = is_enabled;
+                }
+            }
+            TextAreaForm {
+                label: "Value to hash",
+                value: "{hash_generator_state.read().value}",
+                oninput: move |event: Event<FormData>| {
+                    let value = event.value.clone();
+                    hash_generator_state.write().value = value;
+                }
+            }
+            HashField {
+                algorithm: HashingAlgorithm::MD5,
+            }
+            HashField {
+                algorithm: HashingAlgorithm::SHA1,
+            }
+            HashField {
+                algorithm: HashingAlgorithm::SHA256,
+            }
+            HashField {
+                algorithm: HashingAlgorithm::SHA512,
+            }
+        }
+    })
+}
+
+#[allow(non_snake_case)]
+#[inline_props]
+fn HashField(cx: Scope, algorithm: HashingAlgorithm) -> Element {
+    let hash_generator_state = use_shared_state::<HashGeneratorState>(cx).unwrap();
+
+    let hash_generator_state_cur = hash_generator_state.read();
+
+    let mut hasher = select_hasher(*algorithm);
+
+    let hashed_value = generate_hash(
+        hash_generator_state_cur.value.clone(),
+        &mut *hasher,
+        hash_generator_state_cur.uppercase,
+    );
+
+    cx.render(rsx! {
+        TextInput {
+            label: "{algorithm}",
+            value: "{hashed_value}",
+            readonly: true,
+        }
+    })
+}
+
+fn select_hasher(algorithm: HashingAlgorithm) -> Box<dyn DynDigest> {
+    match algorithm {
+        HashingAlgorithm::MD5 => Box::<md5::Md5>::default(),
+        HashingAlgorithm::SHA1 => Box::<sha1::Sha1>::default(),
+        HashingAlgorithm::SHA256 => Box::<sha2::Sha256>::default(),
+        HashingAlgorithm::SHA512 => Box::<sha2::Sha512>::default(),
+    }
+}
+
+fn generate_hash(value: String, hasher: &mut dyn DynDigest, uppercase: bool) -> String {
+    hasher.update(value.as_bytes());
+    let hashed_value = hasher.finalize_reset();
+
+    if uppercase {
+        hashed_value
+            .iter()
+            .map(|byte| format!("{:X}", byte))
+            .collect()
+    } else {
+        hashed_value
+            .iter()
+            .map(|byte| format!("{:x}", byte))
+            .collect()
+    }
+}
+
+struct HashGeneratorState {
+    value: String,
+    uppercase: bool,
+}
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+enum HashingAlgorithm {
+    MD5,
+    SHA1,
+    SHA256,
+    SHA512,
+}
+
+impl fmt::Display for HashingAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -5,6 +5,7 @@ use crate::widget_entry::WidgetEntry;
 pub mod base64_encoder;
 pub mod color_picker;
 pub mod date_converter;
+pub mod hash_generator;
 pub mod home_page;
 pub mod json_yaml_converter;
 pub mod number_base_converter;
@@ -26,5 +27,6 @@ pub static WIDGETS: phf::OrderedMap<&str, &'static [WidgetEntry]> = phf_ordered_
     "Generator" => &[
         qr_code_generator::WIDGET_ENTRY,
         uuid_generator::WIDGET_ENTRY,
+        hash_generator::WIDGET_ENTRY,
     ],
 };

--- a/src/pages/qr_code_generator.rs
+++ b/src/pages/qr_code_generator.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose, Engine as _};
+use base64ct::{Base64, Encoding};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsQrCode;
 
@@ -32,10 +32,9 @@ pub fn qr_code_generator(cx: Scope) -> Element {
         None::<&str>,
     );
     let result = match result {
-        Ok(result) => result,
+        Ok(result) => Base64::encode_string(result.as_bytes()),
         Err(_) => "".to_string(),
     };
-    let result = general_purpose::STANDARD.encode(result);
 
     cx.render(rsx! {
         div {

--- a/src/pages/uuid_generator.rs
+++ b/src/pages/uuid_generator.rs
@@ -21,9 +21,10 @@ pub fn uuid_generator(cx: Scope) -> Element {
     let hyphens_state = use_state(cx, || true);
     let uppercase_state = use_state(cx, || true);
     let num_uuids_state = use_state(cx, || 1);
-    let uuids_state = use_ref(cx, || vec![String::new()]);
+    #[allow(clippy::redundant_closure)]
+    let uuids_state = use_ref(cx, || Vec::<String>::new());
 
-    let uuids = uuids_state.read().join("\n");
+    let uuids = uuids_state.with(|uuids_vec| uuids_vec.join("\n"));
     cx.render(rsx! {
         div {
             class: "uuid-generator",


### PR DESCRIPTION
Adding a new hash generator widget which generates hashes using MD5, SHA1, SHA2-256, and SHA2-512. I got these hash implementations from [RustCrypto/hashes](https://github.com/RustCrypto/hashes).

Improving use_ref handling by replacing .read() and .write() calls with .with() and .with_mut(), where applicable.

Replacing the base64 crate with [base64ct](https://docs.rs/base64ct/latest/base64ct/index.html#), a continuous-time base64 implementation from RustCrypto.