### PR TITLE
Replace chrono-tz with time-tz and improve Time Zone selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,33 +483,8 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1369bc6b9e9a7dfdae2055f6ec151fe9c554a9d23d357c0237cee2e25eaabb7"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.1",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f5ebdc942f57ed96d560a6d1a459bae5851102a25d5bf89dc04ae453e31ecf"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.1",
- "phf_codegen 0.11.2",
 ]
 
 [[package]]
@@ -850,8 +825,6 @@ name = "dev-widgets"
 version = "0.1.0"
 dependencies = [
  "base64ct",
- "chrono",
- "chrono-tz",
  "clap 4.3.11",
  "curl",
  "digest",
@@ -871,7 +844,8 @@ dependencies = [
  "sha2",
  "strum",
  "strum_macros",
- "time 0.3.23",
+ "time",
+ "time-tz",
  "uuid",
  "wasm-bindgen",
  "zip-extract",
@@ -3186,6 +3160,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,23 +3594,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3632,6 +3608,32 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "time-tz"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a422f65dfdf08a81317d54fa00b45dc58cbccab69be78c1447391cc39ae8c9d4"
+dependencies = [
+ "cfg-if",
+ "parse-zoneinfo",
+ "phf 0.11.1",
+ "phf_codegen 0.11.2",
+ "serde",
+ "serde-xml-rs",
+ "thiserror",
+ "time",
+ "windows-sys 0.32.0",
+]
 
 [[package]]
 name = "tinyvec"
@@ -3848,12 +3850,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4127,6 +4123,19 @@ checksum = "ee78911e3f4ce32c1ad9d3c7b0bd95389662ad8d8f1a3155688fed70bd96e2b6"
 
 [[package]]
 name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
@@ -4208,6 +4217,12 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -4217,6 +4232,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4232,6 +4253,12 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -4241,6 +4268,12 @@ name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4265,6 +4298,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4348,6 +4387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a56c84a8ccd4258aed21c92f70c0f6dea75356b6892ae27c24139da456f9336"
+
+[[package]]
 name = "zip"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,7 +4408,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.23",
+ "time",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,9 +790,6 @@ name = "dev-widgets"
 version = "0.1.0"
 dependencies = [
  "base64ct",
- "chrono",
- "chrono-tz",
- "clap",
  "curl",
  "digest",
  "dioxus",
@@ -1937,6 +1940,18 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3702,6 +3717,12 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,6 +3598,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
+ "js-sys",
  "serde",
  "time-core",
  "time-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,55 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,38 +457,11 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "clap"
-version = "4.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.10.0",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cocoa"
@@ -581,12 +505,6 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -825,7 +743,6 @@ name = "dev-widgets"
 version = "0.1.0"
 dependencies = [
  "base64ct",
- "clap 4.3.11",
  "curl",
  "digest",
  "dioxus",
@@ -1625,7 +1542,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cc4b64880a2264a41f9eab431780e72a68a6c88b9bddef361ba638812d572e"
 dependencies = [
- "clap 2.34.0",
+ "clap",
  "grass_compiler",
 ]
 
@@ -1985,18 +1902,6 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi 0.3.2",
- "io-lifetimes",
- "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3407,12 +3312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,12 +3682,6 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "time-tz"
 version = "1.0.3"
-source = "git+https://github.com/esimkowitz/time-tz.git?rev=a59e5bf3545707460cf674def87e9428bd18be86#a59e5bf3545707460cf674def87e9428bd18be86"
+source = "git+https://github.com/esimkowitz/time-tz.git?rev=9bad169699e6f0af98e1a2550e4cb991cade858d#9bad169699e6f0af98e1a2550e4cb991cade858d"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "time-tz"
 version = "1.0.3"
-source = "git+https://github.com/esimkowitz/time-tz.git?rev=13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586#13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586"
+source = "git+https://github.com/esimkowitz/time-tz.git?rev=a59e5bf3545707460cf674def87e9428bd18be86#a59e5bf3545707460cf674def87e9428bd18be86"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "dioxus-web",
  "getrandom 0.2.10",
  "grass",
+ "log",
  "md-5",
  "num-traits",
  "phf 0.11.1",
@@ -812,6 +813,7 @@ dependencies = [
  "time-tz",
  "uuid",
  "wasm-bindgen",
+ "wasm-logger",
  "zip-extract",
 ]
 
@@ -3562,10 +3564,10 @@ dependencies = [
 [[package]]
 name = "time-tz"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a422f65dfdf08a81317d54fa00b45dc58cbccab69be78c1447391cc39ae8c9d4"
+source = "git+https://github.com/esimkowitz/time-tz.git?rev=13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586#13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "parse-zoneinfo",
  "phf 0.11.1",
  "phf_codegen 0.11.2",
@@ -3573,6 +3575,7 @@ dependencies = [
  "serde-xml-rs",
  "thiserror",
  "time",
+ "wasm-bindgen",
  "windows-sys 0.32.0",
 ]
 
@@ -3851,6 +3854,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ zip-extract = "0.1.2"
 
 [dependencies]
 base64ct = { version = "1.6.0", features = ["alloc"] }
-chrono = "0.4.26"
-chrono-tz = "0.8.3"
 digest = "0.10.7"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
@@ -30,6 +28,7 @@ sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 time = "0.3.23"
+time-tz = { version = "1.0.3", features = ["db", "system"] }
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
 wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ digest = "0.10.7"
 dioxus = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 dioxus-free-icons = { git = "https://github.com/esimkowitz/dioxus-free-icons.git", rev = "35995f8577954a83bab2f3b1242bce33d12d3593", features = ["bootstrap"] }
 dioxus-router = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
-getrandom = { version= "0.2.10", features = ["js"] }
 md-5 = "0.10.5"
 num-traits = "0.2.15"
 phf = { version = "0.11.1", features = ["macros"] }
@@ -34,11 +33,13 @@ dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"  }
+getrandom = "0.2.10"
 time = "0.3.23"
 time-tz = { version = "1.0.3", features = ["db", "system"] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 dioxus-web = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+getrandom = { version= "0.2.10", features = ["js"] }
 time = { version = "0.3.23", features = ["wasm-bindgen"]}
 time-tz = { version = "1.0.3", features = ["db"] }
 wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
-time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586" }
+time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "a59e5bf3545707460cf674def87e9428bd18be86" }
 log = { version = "0.4.19", features = ["std"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,22 +26,23 @@ sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
+time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "13faa58f0a6b4c0c4f09fd4764bbc45a9b3fb586" }
+log = { version = "0.4.19", features = ["std"] }
 
-[target."cfg(not(target_family = \"wasm\"))".dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 
-[target."cfg(not(target_family = \"wasm\"))".dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"  }
 getrandom = "0.2.10"
 time = "0.3.23"
-time-tz = { version = "1.0.3", features = ["db", "system"] }
 
-[target."cfg(target_family = \"wasm\")".dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 dioxus-web = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 getrandom = { version= "0.2.10", features = ["js"] }
 time = { version = "0.3.23", features = ["wasm-bindgen"]}
-time-tz = { version = "1.0.3", features = ["db"] }
 wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }
+wasm-logger = "0.2.0"
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,21 @@ sha1 = "0.10.5"
 sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
-time = "0.3.23"
-time-tz = { version = "1.0.3", features = ["db", "system"] }
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
-wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }
 
 [target."cfg(not(target_family = \"wasm\"))".dev-dependencies]
 dioxus-hot-reload = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
 
 [target."cfg(not(target_family = \"wasm\"))".dependencies]
 dioxus-desktop = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab"  }
+time = "0.3.23"
+time-tz = { version = "1.0.3", features = ["db", "system"] }
 
 [target."cfg(target_family = \"wasm\")".dependencies]
 dioxus-web = { git = "https://github.com/DioxusLabs/dioxus.git", rev = "a75223cd8895ca6733164ddf03de314c91c1dbab" }
+time = { version = "0.3.23", features = ["wasm-bindgen"]}
+time-tz = { version = "1.0.3", features = ["db"] }
+wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }
 
 [package.metadata.bundle]
 name = "Dev Widgets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 build = "build.rs"
 
 [build-dependencies]
-clap = "4.3.11"
 curl = "0.4.44"
 grass = "0.12.4"
 zip-extract = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
-time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "a59e5bf3545707460cf674def87e9428bd18be86" }
+time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "9bad169699e6f0af98e1a2550e4cb991cade858d" }
 log = { version = "0.4.19", features = ["std"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,0 +1,19 @@
+use log::*;
+
+#[cfg(not(target_family = "wasm"))]
+mod simple_logger;
+
+pub fn init(level: log::Level) {
+    #[cfg(target_family = "wasm")]
+    {
+        wasm_logger::init(wasm_logger::Config::new(level));
+    }
+    
+    #[cfg(not(target_family = "wasm"))]
+    {
+        match set_boxed_logger(Box::new(simple_logger::SimpleLogger)) {
+            Ok(_) => log::set_max_level(level.to_level_filter()),
+            Err(e) => panic!("Failed to initialize logger: {}", e),
+        }
+    }
+}

--- a/src/logger/simple_logger.rs
+++ b/src/logger/simple_logger.rs
@@ -1,0 +1,17 @@
+use log::{Record, Metadata};
+
+pub struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,22 @@ use std::env;
 
 const USE_HOT_RELOAD: bool = false;
 
+mod logger;
+
 fn main() {
+    let mut log_level = log::Level::Warn;
     if cfg!(debug_assertions) {
         #[cfg(not(target_family = "wasm"))]
         env::set_var("RUST_BACKTRACE", "1");
         if USE_HOT_RELOAD {
             environment::init_hot_reload();
         }
+        log_level = log::Level::Info;
     }
+
+    logger::init(log_level);
+
+    log::info!("Starting app");
 
     environment::init(App);
 }

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -4,7 +4,10 @@ use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
 use strum::IntoEnumIterator;
 use time::{Month, OffsetDateTime, UtcOffset};
-use time_tz::{system, timezones, OffsetDateTimeExt, TimeZone, Tz};
+use time_tz::{timezones, OffsetDateTimeExt, TimeZone, Tz};
+
+#[cfg(not(target_family = "wasm"))]
+use time_tz::system;
 
 use crate::{
     components::inputs::{NumberInput, SelectForm, SelectFormEnum, TextInput},
@@ -162,8 +165,15 @@ enum DcTimeZone {
 }
 
 impl Default for DcTimeZone {
+    #[cfg(not(target_family = "wasm"))]
     fn default() -> Self {
         Self::Base(system::get_timezone().unwrap_or(timezones::db::UTC))
+    }
+
+
+    #[cfg(target_family = "wasm")]
+    fn default() -> Self {
+        Self::Base(timezones::db::UTC)
     }
 }
 

--- a/src/pages/date_converter.rs
+++ b/src/pages/date_converter.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc};
-use chrono_tz::{ParseError, Tz, TZ_VARIANTS};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsClock;
 use strum::IntoEnumIterator;
+use time::{Month, OffsetDateTime, UtcOffset};
+use time_tz::{system, timezones, OffsetDateTimeExt, TimeZone, Tz};
 
 use crate::{
     components::inputs::{NumberInput, SelectForm, SelectFormEnum, TextInput},
@@ -25,11 +25,11 @@ const ICON: WidgetIcon<BsClock> = WidgetIcon { icon: BsClock };
 pub fn date_converter(cx: Scope) -> Element {
     let date_state = use_ref(cx, || DateConverterState {
         time_zone: DcTimeZone::default(),
-        time: Utc::now().naive_utc(),
+        time_utc: OffsetDateTime::now_utc(),
     });
 
     let local_datetime = date_state.with(|date_state| date_state.local_datetime());
-    let unix_time = date_state.with(|date_state| date_state.time.timestamp());
+    let unix_time = date_state.with(|date_state| date_state.time_utc.unix_timestamp());
 
     cx.render(rsx! {
         div {
@@ -54,9 +54,9 @@ pub fn date_converter(cx: Scope) -> Element {
                 onchange: move |event: Event<FormData>| {
                     let new_unix_time = event.value.clone();
                     if let Ok(unix_time) = i64::from_str(&new_unix_time) {
-                        if let chrono::LocalResult::Single(datetime) = Utc.timestamp_opt(unix_time, 0) {
+                        if let Ok(datetime) = OffsetDateTime::from_unix_timestamp(unix_time) {
                             date_state.with_mut(|date_state| {
-                                date_state.time = datetime.naive_utc();
+                                date_state.set_local_datetime(datetime);
                             });
                         }
                     }
@@ -74,27 +74,27 @@ pub fn date_converter(cx: Scope) -> Element {
                             value: local_datetime.year(),
                             onchange: move |year| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_year(year).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_year(year).unwrap_or(local_datetime));
                                 });
                             }
                         }
-                        NumberInput::<u32> {
+                        NumberInput::<u8> {
                             class: "month",
                             label: "Month",
-                            value: local_datetime.month(),
+                            value: u8::from(local_datetime.month()),
                             onchange: move |month| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_month(month).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_month(Month::try_from(month).unwrap_or(local_datetime.month())).unwrap_or(local_datetime));
                                 });
                             }
                         }
-                        NumberInput::<u32> {
+                        NumberInput::<u8> {
                             class: "day",
                             label: "Day",
                             value: local_datetime.day(),
                             onchange: move |day| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_day(day).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_day(day).unwrap_or(local_datetime));
                                 });
                             }
                         }
@@ -104,33 +104,33 @@ pub fn date_converter(cx: Scope) -> Element {
                     class: "hms selectors",
                     div {
                         class: "selectors-inner",
-                        NumberInput::<u32> {
+                        NumberInput::<u8> {
                             class: "hour",
                             label: "Hour",
                             value: local_datetime.hour(),
                             onchange: move |hour| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_hour(hour).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_hour(hour).unwrap_or(local_datetime));
                                 });
                             }
                         }
-                        NumberInput::<u32> {
+                        NumberInput::<u8> {
                             class: "minute",
                             label: "Minute",
                             value: local_datetime.minute(),
                             onchange: move |minute| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_minute(minute).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_minute(minute).unwrap_or(local_datetime));
                                 });
                             }
                         }
-                        NumberInput::<u32> {
+                        NumberInput::<u8> {
                             class: "second",
                             label: "Second",
                             value: local_datetime.second(),
                             onchange: move |second| {
                                 date_state.with_mut(|date_state| {
-                                    date_state.set_local_datetime(local_datetime.with_second(second).unwrap_or(local_datetime));
+                                    date_state.set_local_datetime(local_datetime.replace_second(second).unwrap_or(local_datetime));
                                 });
                             }
                         }
@@ -141,45 +141,56 @@ pub fn date_converter(cx: Scope) -> Element {
     })
 }
 
-#[derive(Clone, Copy)]
 struct DateConverterState {
     time_zone: DcTimeZone,
-    time: NaiveDateTime,
+    time_utc: OffsetDateTime,
 }
 
 impl DateConverterState {
-    fn local_datetime(&self) -> DateTime<Tz> {
-        self.time_zone.inner().from_utc_datetime(&self.time)
+    fn local_datetime(&self) -> OffsetDateTime {
+        self.time_utc.to_timezone(self.time_zone.inner())
     }
 
-    fn set_local_datetime(&mut self, datetime: DateTime<Tz>) {
-        self.time = datetime.naive_utc();
+    fn set_local_datetime(&mut self, datetime: OffsetDateTime) {
+        self.time_utc = datetime.to_offset(UtcOffset::UTC);
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug, Clone, Copy)]
 enum DcTimeZone {
-    Base(Tz),
+    Base(&'static Tz),
 }
 
 impl Default for DcTimeZone {
     fn default() -> Self {
-        Self::Base(Tz::UTC)
+        Self::Base(system::get_timezone().unwrap_or(timezones::db::UTC))
     }
 }
 
 impl Display for DcTimeZone {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner())
+        write!(f, "{:?}", self.inner())
     }
 }
 
 impl FromStr for DcTimeZone {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::Base(Tz::from_str(s)?))
+        match timezones::get_by_name(s) {
+            Some(tz) => Ok(Self::Base(tz)),
+            None => Err(TzParseError),
+        }
     }
 
-    type Err = ParseError;
+    type Err = TzParseError;
+}
+
+#[derive(Debug, Clone)]
+struct TzParseError;
+
+impl Display for TzParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        "invalid timezone".fmt(f)
+    }
 }
 
 impl PartialEq for DcTimeZone {
@@ -190,9 +201,8 @@ impl PartialEq for DcTimeZone {
 
 impl IntoEnumIterator for DcTimeZone {
     fn iter() -> Self::Iterator {
-        TZ_VARIANTS
-            .iter()
-            .map(|tz| Self::Base(*tz))
+        timezones::iter()
+            .map(Self::Base)
             .collect::<Vec<_>>()
             .into_iter()
     }
@@ -209,7 +219,7 @@ impl From<DcTimeZone> for &'static str {
 impl SelectFormEnum for DcTimeZone {}
 
 impl DcTimeZone {
-    fn inner(&self) -> Tz {
+    fn inner(&self) -> &'static Tz {
         match self {
             Self::Base(tz) => *tz,
         }


### PR DESCRIPTION
This PR updates the DateTime converter implementation to use the [time-tz crate](https://github.com/Yuri6037/time-tz) instead of chrono-tz. This patches https://github.com/esimkowitz/dev-widgets/security/dependabot/1. It also adds functionality to get the local timezone for the target system. The specific revision of this crate used here includes a proposed change I have added which extends support for getting the local time zone to WASM targets (https://github.com/Yuri6037/time-tz/pull/14).

This PR also adds support for logging, replacing use of println! in the application logic. This way, support for logging will be equal for both WASM and desktop targets. It also removes an unnecessary direct clap dependency.