### PR TITLE
Update time-tz to use crate feed again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,8 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "time-tz"
-version = "1.0.3"
-source = "git+https://github.com/esimkowitz/time-tz.git?rev=9bad169699e6f0af98e1a2550e4cb991cade858d#9bad169699e6f0af98e1a2550e4cb991cade858d"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733bc522e97980eb421cbf381160ff225bd14262a48a739110f6653c6258d625"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.10.7"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 uuid = { version = "1.4.0", features = ["v4", "fast-rng"] }
-time-tz = { version = "1.0.3", features = ["db", "system"], git = "https://github.com/esimkowitz/time-tz.git", rev = "9bad169699e6f0af98e1a2550e4cb991cade858d" }
+time-tz = { version = "2.0.0", features = ["db", "system"] }
 log = { version = "0.4.19", features = ["std"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]


### PR DESCRIPTION
The change I made has been merged and a new version is now published so I am updating Cargo.toml to reference the public crate feed again.