### PR TITLE
Update CIDR decoder to use cleaner layout, no onsubmit

### DIFF
--- a/scss/pages/cidr_decoder.scss
+++ b/scss/pages/cidr_decoder.scss
@@ -1,3 +1,6 @@
 div.cidr-decoder {
-  @extend .d-grid, .column, .row-gap-3;
+  @extend .d-flex, .flex-column, .row-gap-3, .h-100;
+  .textarea-form {
+    flex: 1 1 auto;
+  }
 }

--- a/src/components/inputs.rs
+++ b/src/components/inputs.rs
@@ -30,10 +30,8 @@ pub fn SelectForm<'a, T: SelectFormEnum>(cx: Scope<'a, SelectFormProps<'a, T>>) 
             select {
                 id: "{cx.props.label}",
                 aria_label: "{cx.props.label}",
-                oninput: move |event| {
-                    if let Ok(value) = T::from_str(&event.value) {
-                        cx.props.oninput.call(value);
-                    }
+                oninput: move |event| if let Ok(value) = T::from_str(&event.value) {
+                    cx.props.oninput.call(value);
                 },
                 for enumInst in T::iter() {
                     option {
@@ -103,13 +101,11 @@ pub fn TextAreaForm<'a>(
             id: "{label}",
             textarea {
                 value: "{value}",
-                oninput:  move |event| match oninput {
-                    Some(oninput) => oninput.call(event),
-                    None => {}
+                oninput:  move |event| if let Some(oninput) = oninput {
+                    oninput.call(event);
                 },
-                onchange: move |event| match onchange {
-                    Some(onchange) => onchange.call(event),
-                    None => {}
+                onchange: move |event| if let Some(onchange) = onchange {
+                    onchange.call(event);
                 },
                 readonly: readonly,
             }
@@ -128,48 +124,27 @@ pub fn TextInput<'a>(
     label: &'a str,
     oninput: Option<EventHandler<'a, Event<FormData>>>,
     onchange: Option<EventHandler<'a, Event<FormData>>>,
-    onsubmit: Option<EventHandler<'a, String>>,
     readonly: Option<bool>,
 ) -> Element<'a> {
     let readonly = readonly.unwrap_or(false);
 
-    let form_state = use_ref(cx, || value.to_string());
-
-    let input_group_css = if onsubmit.is_some() {
-        "input-group"
-    } else {
-        ""
-    };
-
-    let set_value = |value: String| {
-        if onsubmit.is_some() {
-            form_state.with_mut(|form_value| {
-                *form_value = value.clone();
-            });
-        }
-    };
-
     cx.render(rsx! {
         div {
-            class: "text-input {input_group_css}",
+            class: "text-input",
             div {
                 class: "form-floating",
                 input {
                     class: "form-control",
                     r#type: "text",
                     value: "{value}",
-                    oninput: move |event| match oninput {
-                        Some(oninput) => {
-                            set_value(event.value.clone());
-                            oninput.call(event)
-                        },
-                        None => {}
+                    oninput: move |event| {
+                        if let Some(oninput) = oninput {
+                            oninput.call(event);
+                        }
                     },
                     onchange: move |event| {
-                        set_value(event.value.clone());
-                        match onchange {
-                            Some(onchange) => onchange.call(event),
-                            None => {}
+                        if let Some(onchange) = onchange {
+                            onchange.call(event);
                         }
                     },
                     readonly: readonly
@@ -177,22 +152,6 @@ pub fn TextInput<'a>(
                 label {
                     r#for: "{label}",
                     *label
-                }
-            }
-            if let Some(onsubmit) = onsubmit {
-                rsx! { 
-                    button {
-                        class: "btn btn-primary",
-                        r#type: "submit",
-                        onclick: move |_| {
-                            let mut value = String::default();
-                            form_state.with(|form_value| {
-                                value = form_value.clone();
-                            });
-                            onsubmit.call(value);
-                        },
-                        "Submit"
-                    }
                 }
             }
         }
@@ -218,10 +177,8 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
                         r#type: "number",
                         value: "{value}",
                         id: "{label}",
-                        onchange: move |event| {
-                            if let Ok(value) = event.value.parse::<T>() {
-                                onchange.call(value);
-                            }
+                        onchange: move |event| if let Ok(value) = event.value.parse::<T>() {
+                            onchange.call(value);
                         }
                     }
                     label {
@@ -232,10 +189,8 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
                 div {
                     class: "inc-dec-buttons",
                     button {
-                        onclick: move |_| {
-                            if let Some(value) = value.checked_add(&T::one()) {
-                                onchange.call(value);
-                            };
+                        onclick: move |_| if let Some(value) = value.checked_add(&T::one()) {
+                            onchange.call(value);
                         },
                         Icon {
                             icon: BsPlus,
@@ -245,10 +200,8 @@ pub fn NumberInput<'a, T: PrimInt + Display + Default + FromStr>(
                         }
                     }
                     button {
-                        onclick: move |_| {
-                            if let Some(value) = value.checked_sub(&T::one()) {
-                                onchange.call(value);
-                            };
+                        onclick: move |_| if let Some(value) = value.checked_sub(&T::one()) {
+                            onchange.call(value);
                         },
                         Icon {
                             icon: BsDash,


### PR DESCRIPTION
I found the layout of the CIDR decoder unpleasant. It was too hard to understand how to input the CIDR, the onsubmit form was finicky, and I missed being able to get live feedback on the validity of the input CIDR string. I reworked it so the details of the CIDR range are in a readonly TextArea form and I just store the input state separately and only update the IpCidr ref when a new valid one is present.