### PR TITLE
Fix handling of paths when refreshing from GitHub Pages

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           trunk build --release
 
+      - name: Copy 404.html to target dir
+        run: |
+          cp ./public/404.html ./dist
+
       # Upload artifact
       - name: Fix permissions for artifact upload
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ time = "0.3.23"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 dioxus-web = "0.4.0"
-getrandom = { version= "0.2.10", features = ["js"] }
-time = { version = "0.3.23", features = ["wasm-bindgen"]}
+getrandom = { version = "0.2.10", features = ["js"] }
+time = { version = "0.3.23", features = ["wasm-bindgen"] }
 wasm-bindgen = { version = "0.2.87", features = ["enable-interning"] }
 wasm-logger = "0.2.0"
 

--- a/Dioxus.toml
+++ b/Dioxus.toml
@@ -1,7 +1,7 @@
 [application]
 
 # dioxus project name
-name = "dev-widgets"
+name = "Dev Widgets"
 
 # default platfrom
 # you can also use `dioxus serve/build --platform XXX` to use other platform
@@ -21,7 +21,7 @@ title = "Dev Widgets"
 
 [web.watcher]
 
-watch_path = ["src","scss","index.html"]
+watch_path = ["src", "scss", "index.html"]
 reload_html = true
 index_on_404 = true
 
@@ -41,3 +41,11 @@ script = []
 script = []
 
 [application.tools]
+
+[bundle]
+identifier = "com.esimkowitz.devwidgets"
+publisher = "Evan Simkowitz"
+resources = ["public/**/*"]
+copyright = "Copyright (c) Evan Simkowitz 2023. All rights reserved."
+category = "Developer Tool"
+short_description = "A set of helpful widgets written in Rust."

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-bs-theme="light">
+<html lang="en-US" data-bs-theme="light">
   <head>
     <title></title>
     <link rel="stylesheet" href="style/style.css" />

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dev Widgets</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
-components = [ "rustfmt", "rustc", "clippy", "cargo" ]
-targets = [ "wasm32-unknown-unknown" ]
+components = ["rustfmt", "rustc", "clippy", "cargo"]
+targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/src/environment/desktop.rs
+++ b/src/environment/desktop.rs
@@ -8,19 +8,18 @@ pub fn init_app(root: Component) {
     // Configure dioxus-desktop Tauri window
     let config_builder = DesktopConfig::default().with_custom_index(
         r#"
-                <!DOCTYPE html>
-                <html data-bs-theme="light">
-                    <head>
-                        <link rel="stylesheet" href="style/style.css">
-                        <meta name="viewport" content="width=device-width, initial-scale=1">
-                    </head>
-                    <body>
-                        <div id="main"></div>
-                        <script type="text/javascript" src="js/darkmode.js"></script>
-                        <script type="text/javascript" src="js/bootstrap.min.js"></script>
-                    </body>
-                </html>
-            "#
+            <!DOCTYPE html>
+            <html data-bs-theme="light">
+                <head>
+                    <link rel="stylesheet" href="style/style.css">
+                    <meta name="viewport" content="width=device-width, initial-scale=1">
+                </head>
+                <body>
+                    <div id="main"></div>
+                    <script type="text/javascript" src="js/darkmode.js"></script>
+                </body>
+            </html>
+        "#
         .to_string(),
     );
 

--- a/trunk.html
+++ b/trunk.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-bs-theme="light">
+<html lang="en-US" data-bs-theme="light">
   <head>
     <title>Dev Widgets</title>
     <link data-trunk rel="css" href="public/style/style.css" />


### PR DESCRIPTION
This PR overcomes a quirk of GitHub Pages where dynamic paths cannot be processed when the page is refreshed, since they are not present in the static site map that GitHub Pages creates. To handle this, we overload the GitHub Pages 404 page with one that has a script to parse the intended path from the browser and redirect to the index, applying the dynamic path.

This also includes some cleanup of the Dioxus configs. There's a problem with the Dioxus CLI where assets being included in the desktop bundle use a different path structure than either cargo-bundle or building for the Dioxus Web. There's an open issue (https://github.com/DioxusLabs/dioxus/issues/1283) to remedy this, but for now I am going to stick with using cargo-bundle. Bundling with the Dioxus CLI will not package the CSS/JS.