### PR TITLE
Add the missing second part of the SPA redirect solution

### DIFF
--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_family = "wasm"))]
 use log::*;
 
 #[cfg(not(target_family = "wasm"))]

--- a/trunk.html
+++ b/trunk.html
@@ -5,6 +5,30 @@
     <link data-trunk rel="css" href="public/style/style.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base data-trunk-public-url/>
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
   </head>
   <body>
     <div id="main"></div>


### PR DESCRIPTION
Add the missing part in the index.html to parse the query string back into a proper SPA dynamic path and push it to the browser.

Also fixes a build warning about an unused logging import when building for WASM.