### PR TITLE
Remove unmaintained actions-rs/toolchain

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -14,11 +14,10 @@ jobs:
       
       # Install toolchain
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
       - name: Configure Cargo cache
         uses: Swatinem/rust-cache@v2
       - name: Install Trunk

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Install Dioxus dependencies
         run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+      
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
+          targets: wasm32-unknown-unknown
           components: clippy
-          override: true
 
       - name: Configure Cargo cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The actions-rs organization appears to be [unmaintained since 2020](https://www.reddit.com/r/rust/comments/z1mlls/actionsrs_github_actions_need_more_maintainers_or/). I found [rust-toolchain](https://github.com/dtolnay/rust-toolchain) from [this comment](https://github.com/actions-rs/toolchain/issues/216#issuecomment-1184809175). This action is much slimmer but accomplishes the same thing in around the same amount of time.