### PR TITLE
Resolve new clippy warning about string allocations when using collect

### DIFF
--- a/src/pages/generator/hash_generator.rs
+++ b/src/pages/generator/hash_generator.rs
@@ -2,7 +2,7 @@
 use digest::DynDigest;
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::bs_icons::BsFingerprint;
-use std::fmt;
+use std::fmt::{self, Write};
 
 use crate::components::inputs::{SwitchInput, TextAreaForm, TextInput};
 use crate::pages::{WidgetEntry, WidgetIcon};
@@ -99,13 +99,17 @@ fn generate_hash(value: String, hasher: &mut dyn DynDigest, uppercase: bool) -> 
     if uppercase {
         hashed_value
             .iter()
-            .map(|byte| format!("{:X}", byte))
-            .collect()
+            .fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{:X}", b);
+                output
+            })
     } else {
         hashed_value
             .iter()
-            .map(|byte| format!("{:x}", byte))
-            .collect()
+            .fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{:x}", b);
+                output
+            })
     }
 }
 


### PR DESCRIPTION
Resolves new warning in 1.73.0: https://rust-lang.github.io/rust-clippy/master/index.html#/format_collect