### PR TITLE
Fix Date/Time Converter TZ dropdowns

### DIFF
--- a/src/pages/converter/date_converter.rs
+++ b/src/pages/converter/date_converter.rs
@@ -193,7 +193,7 @@ impl FromStr for DcTimeZone {
 
 impl From<DcTimeZone> for String {
     fn from(val: DcTimeZone) -> Self {
-        val.to_string()
+        val.inner().name().to_string()
     }
 }
 


### PR DESCRIPTION
The dropdown was showing the full to_string of the Tz struct rather than just the name. This is now fixed.