### PR TITLE
fix colors of color view border

### DIFF
--- a/scss/pages/color_picker.scss
+++ b/scss/pages/color_picker.scss
@@ -87,7 +87,7 @@ div.color-picker {
       width: $color_view_height;
       border-radius: calc($color_view_height * 0.5);
       background-color: var(--color-view-background);
-      border: solid $border_width var(--bs-dark);
+      border: solid var(--bs-border-width) var(--bs-border-color);
     }
     .text-input, .select-form {
       margin: auto;


### PR DESCRIPTION
Use the Bootstrap variables for the color and size of the color view border. This way, it will display nicely in both light and dark mode, even if the colors are close to that of the background.